### PR TITLE
Add Behroozi 2019 smhm

### DIFF
--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013.py
@@ -33,7 +33,7 @@ comment = (
     "Cosmology: Omega_m = 0.27, ns = 0.95, Omega_b = 0.046, sigma_8 = 0.82, h = 0.7."
     "No cosmology correction needed. "
     "Halo masses have been corrected from M_vir to M_200_cr."
-    "Shows the relation betweeen stellar mass and halo mass."
+    "Shows the relation between stellar mass and halo mass."
 )
 citation = "Behroozi et al. (2013)"
 bibcode = "2013ApJ...770...57B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013Ratio.py
@@ -39,7 +39,7 @@ comment = (
     "Cosmology: Omega_m = 0.27, ns = 0.95, Omega_b = 0.046, sigma_8 = 0.82, h = 0.7."
     "No cosmology correction needed. "
     "Halo masses have been corrected from M_vir to M_200_cr."
-    "Shows the ratio betweeen stellar mass and halo mass."
+    "Shows the ratio between stellar mass and halo mass."
 )
 citation = "Behroozi et al. (2013)"
 bibcode = "2013ApJ...770...57B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2013RatioStellar.py
@@ -29,7 +29,7 @@ comment = (
     "Stellar Masses: Chabrier IMF, BC03 SPS model, Blanton et al. dust model (i.e., kcorrect)."
     "Cosmology: Omega_m = 0.27, ns = 0.95, Omega_b = 0.046, sigma_8 = 0.82, h = 0.7."
     "No cosmology correction needed. "
-    "Shows the ratio betweeen stellar mass and halo mass as a function of stellar mass."
+    "Shows the ratio between stellar mass and halo mass as a function of stellar mass."
 )
 citation = "Behroozi et al. (2013)"
 bibcode = "2013ApJ...770...57B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -33,15 +33,15 @@ M_200 = M_vir / 1.2
 
 # Meta-data
 comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median fit to the raw data for centrals (i.e. excluding satellites)"
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
-    "spherical overdensity definition"
-    "The fitting function does not include the intrahalo light contribution to the"
-    "stellar mass"
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
-    "Shows the stellar mass as a function halo mass"
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
+    "Shows the stellar mass as a function halo mass."
 )
 citation = "Behroozi et al. (2019)"
 bibcode = "2019MNRAS.488.3143B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -13,66 +13,68 @@ with open(sys.argv[1], "r") as handle:
 # Cosmology
 h_sim = cosmology.h
 
-output_filename = "Behroozi2019.hdf5"
-output_directory = "../"
+# Redshifts at which to plot the data
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 
-if not os.path.exists(output_directory):
-    os.mkdir(output_directory)
+# Create and save data for each z in redshifts
+for z in redshifts:
 
-# Redshift at which to plot the data
-redshift = 0.0
+    output_filename = f"Behroozi2019_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_directory = "../"
 
-M_vir = np.logspace(9, 15, 512)
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
 
-# Note that the function below actually takes M_{vir, peak}, and we are
-# ignoring this fact
-M_star = behroozi_2019_raw(redshift, M_vir)
+    M_BN98 = np.logspace(9, 15, 512)
 
-# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
-M_200 = M_vir / 1.2
+    # Note that the function below actually takes M_{BN98, peak}, and we are
+    # ignoring this fact
+    M_star = behroozi_2019_raw(z, M_BN98)
 
-# Meta-data
-comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html. "
-    "Median fit to the raw data for centrals (i.e. excluding satellites). "
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-    "spherical overdensity definition. "
-    "The fitting function does not include the intrahalo light contribution to the "
-    "stellar mass. "
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
-    "Shows the stellar mass as a function halo mass."
-)
-citation = "Behroozi et al. (2019)"
-bibcode = "2019MNRAS.488.3143B"
-name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
-plot_as = "line"
-h = h_sim
+    # Meta-data
+    comment = (
+        "The data is taken from https://www.peterbehroozi.com/data.html. "
+        "Median fit to the raw data for centrals (i.e. excluding satellites). "
+        "The stellar mass is the true stellar mass (i.e. w/o observational "
+        "corrections). "
+        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+        "spherical overdensity definition. "
+        "The fitting function does not include the intrahalo light contribution to the "
+        "stellar mass. "
+        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+        "n_s=0.96. "
+        "Shows the stellar mass as a function halo mass."
+    )
+    citation = "Behroozi et al. (2019)"
+    bibcode = "2019MNRAS.488.3143B"
+    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
+    plot_as = "line"
+    h = h_sim
 
-# Write everything
-processed = ObservationalData()
-processed.associate_x(
-    M_200 * unyt.Solar_Mass,
-    scatter=None,
-    comoving=True,
-    description="Halo Mass ($M_{200, {\rm crit}}$)",
-)
-processed.associate_y(
-    M_star * unyt.Solar_Mass,
-    scatter=None,
-    comoving=True,
-    description="Galaxy Stellar Mass",
-)
-processed.associate_citation(citation, bibcode)
-processed.associate_name(name)
-processed.associate_comment(comment)
-processed.associate_redshift(redshift)
-processed.associate_plot_as(plot_as)
-processed.associate_cosmology(cosmology)
+    # Write everything
+    processed = ObservationalData()
+    processed.associate_x(
+        M_BN98 * unyt.Solar_Mass,
+        scatter=None,
+        comoving=True,
+        description=r"Halo Mass ($M_{\rm BN98}$)",
+    )
+    processed.associate_y(
+        M_star * unyt.Solar_Mass,
+        scatter=None,
+        comoving=True,
+        description="Galaxy Stellar Mass",
+    )
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_redshift(z)
+    processed.associate_plot_as(plot_as)
+    processed.associate_cosmology(cosmology)
 
-output_path = f"{output_directory}/{output_filename}"
+    output_path = f"{output_directory}/{output_filename}"
 
-if os.path.exists(output_path):
-    os.remove(output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
 
-processed.write(filename=output_path)
+    processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -19,7 +19,7 @@ redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 # Create and save data for each z in redshifts
 for z in redshifts:
 
-    output_filename = f"Behroozi2019_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_filename = f"Behroozi2019_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
     output_directory = "../"
 
     if not os.path.exists(output_directory):
@@ -57,7 +57,7 @@ for z in redshifts:
         M_BN98 * unyt.Solar_Mass,
         scatter=None,
         comoving=True,
-        description=r"Halo Mass ($M_{\rm BN98}$)",
+        description="Halo Mass ($M_{\\rm BN98}$)",
     )
     processed.associate_y(
         M_star * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -1,0 +1,76 @@
+from velociraptor.observations.objects import ObservationalData
+from velociraptor.fitting_formulae.smhmr import behroozi_2019_raw
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmology
+h_sim = cosmology.h
+
+output_filename = "Behroozi2019.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+# Redshift at which to plot the data
+redshift = 2.0
+
+M_vir = np.logspace(7, 15, 512)
+
+# Note that the function below actually takes M_{vir, peak}, and we are
+# ignoring this fact
+M_star = behroozi_2019_raw(redshift, M_vir)
+
+# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
+M_200 = M_vir / 1.2
+
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html"
+    "Median Fit to the raw data including both satellites and centrals."
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
+    "spherical overdensity definition"
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
+    "Shows the stellar mass as a function halo mass"
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
+plot_as = "line"
+h = h_sim
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_200 * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Halo Mass ($M_{200, {\rm crit}}$)",
+)
+processed.associate_y(
+    M_star * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -20,9 +20,9 @@ if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
 # Redshift at which to plot the data
-redshift = 2.0
+redshift = 0.0
 
-M_vir = np.logspace(7, 15, 512)
+M_vir = np.logspace(9, 15, 512)
 
 # Note that the function below actually takes M_{vir, peak}, and we are
 # ignoring this fact
@@ -34,10 +34,12 @@ M_200 = M_vir / 1.2
 # Meta-data
 comment = (
     "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median Fit to the raw data including both satellites and centrals."
+    "Median fit to the raw data for centrals (i.e. excluding satellites)"
     "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
     "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
     "spherical overdensity definition"
+    "The fitting function does not include the intrahalo light contribution to the"
+    "stellar mass"
     "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
     "Shows the stellar mass as a function halo mass"
 )

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -1,0 +1,76 @@
+from velociraptor.observations.objects import ObservationalData
+from velociraptor.fitting_formulae.smhmr import behroozi_2019_raw
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmology
+h_sim = cosmology.h
+
+output_filename = "Behroozi2019Ratio.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+# Redshift at which to plot the data
+redshift = 0.0
+
+M_vir = np.logspace(7, 15, 512)
+
+# Note that the function below actually takes M_{vir, peak}, and we are
+# ignoring this fact
+M_star = behroozi_2019_raw(redshift, M_vir)
+
+# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
+M_200 = M_vir / 1.2
+
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html"
+    "Median Fit to the raw data including both satellites and centrals."
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
+    "spherical overdensity definition"
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
+    "Shows the ratio between stellar mass and halo mass as a function of halo mass"
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
+plot_as = "line"
+h = h_sim
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_200 * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Halo Mass ($M_{200, {\rm crit}}$)",
+)
+processed.associate_y(
+    (M_star / M_200) * unyt.dimensionless,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{200, {\rm crit}}$)",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -22,7 +22,7 @@ if not os.path.exists(output_directory):
 # Redshift at which to plot the data
 redshift = 0.0
 
-M_vir = np.logspace(7, 15, 512)
+M_vir = np.logspace(9, 15, 512)
 
 # Note that the function below actually takes M_{vir, peak}, and we are
 # ignoring this fact
@@ -34,10 +34,12 @@ M_200 = M_vir / 1.2
 # Meta-data
 comment = (
     "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median Fit to the raw data including both satellites and centrals."
+    "Median fit to the raw data for centrals (i.e. excluding satellites)"
     "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
     "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
     "spherical overdensity definition"
+    "The fitting function does not include the intrahalo light contribution to the"
+    "stellar mass"
     "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
     "Shows the ratio between stellar mass and halo mass as a function of halo mass"
 )

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -19,7 +19,7 @@ redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 # Create and save data for each z in redshifts
 for z in redshifts:
 
-    output_filename = f"Behroozi2019Ratio_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_filename = f"Behroozi2019Ratio_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
     output_directory = "../"
 
     if not os.path.exists(output_directory):
@@ -57,13 +57,13 @@ for z in redshifts:
         M_BN98 * unyt.Solar_Mass,
         scatter=None,
         comoving=True,
-        description=r"Halo Mass ($M_{\rm BN98}$)",
+        description="Halo Mass ($M_{\\rm BN98}$)",
     )
     processed.associate_y(
         (M_star / M_BN98) * unyt.dimensionless,
         scatter=None,
         comoving=True,
-        description=r"Galaxy Stellar Mass / Halo Mass ($M_* / M_{\rm BN98}$)",
+        description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{\\rm BN98}$)",
     )
     processed.associate_citation(citation, bibcode)
     processed.associate_name(name)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -33,15 +33,15 @@ M_200 = M_vir / 1.2
 
 # Meta-data
 comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median fit to the raw data for centrals (i.e. excluding satellites)"
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
-    "spherical overdensity definition"
-    "The fitting function does not include the intrahalo light contribution to the"
-    "stellar mass"
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
-    "Shows the ratio between stellar mass and halo mass as a function of halo mass"
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
+    "Shows the ratio between stellar mass and halo mass as a function of halo mass."
 )
 citation = "Behroozi et al. (2019)"
 bibcode = "2019MNRAS.488.3143B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -13,66 +13,68 @@ with open(sys.argv[1], "r") as handle:
 # Cosmology
 h_sim = cosmology.h
 
-output_filename = "Behroozi2019Ratio.hdf5"
-output_directory = "../"
+# Redshifts at which to plot the data
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 
-if not os.path.exists(output_directory):
-    os.mkdir(output_directory)
+# Create and save data for each z in redshifts
+for z in redshifts:
 
-# Redshift at which to plot the data
-redshift = 0.0
+    output_filename = f"Behroozi2019Ratio_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_directory = "../"
 
-M_vir = np.logspace(9, 15, 512)
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
 
-# Note that the function below actually takes M_{vir, peak}, and we are
-# ignoring this fact
-M_star = behroozi_2019_raw(redshift, M_vir)
+    M_BN98 = np.logspace(9, 15, 512)
 
-# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
-M_200 = M_vir / 1.2
+    # Note that the function below actually takes M_{BN98, peak}, and we are
+    # ignoring this fact
+    M_star = behroozi_2019_raw(z, M_BN98)
 
-# Meta-data
-comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html. "
-    "Median fit to the raw data for centrals (i.e. excluding satellites). "
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-    "spherical overdensity definition. "
-    "The fitting function does not include the intrahalo light contribution to the "
-    "stellar mass. "
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
-    "Shows the ratio between stellar mass and halo mass as a function of halo mass."
-)
-citation = "Behroozi et al. (2019)"
-bibcode = "2019MNRAS.488.3143B"
-name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
-plot_as = "line"
-h = h_sim
+    # Meta-data
+    comment = (
+        "The data is taken from https://www.peterbehroozi.com/data.html. "
+        "Median fit to the raw data for centrals (i.e. excluding satellites). "
+        "The stellar mass is the true stellar mass (i.e. w/o observational "
+        "corrections). "
+        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+        "spherical overdensity definition. "
+        "The fitting function does not include the intrahalo light contribution to the "
+        "stellar mass. "
+        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+        "n_s=0.96. "
+        "Shows the ratio between stellar mass and halo mass as a function of halo mass."
+    )
+    citation = "Behroozi et al. (2019)"
+    bibcode = "2019MNRAS.488.3143B"
+    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
+    plot_as = "line"
+    h = h_sim
 
-# Write everything
-processed = ObservationalData()
-processed.associate_x(
-    M_200 * unyt.Solar_Mass,
-    scatter=None,
-    comoving=True,
-    description="Halo Mass ($M_{200, {\rm crit}}$)",
-)
-processed.associate_y(
-    (M_star / M_200) * unyt.dimensionless,
-    scatter=None,
-    comoving=True,
-    description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{200, {\rm crit}}$)",
-)
-processed.associate_citation(citation, bibcode)
-processed.associate_name(name)
-processed.associate_comment(comment)
-processed.associate_redshift(redshift)
-processed.associate_plot_as(plot_as)
-processed.associate_cosmology(cosmology)
+    # Write everything
+    processed = ObservationalData()
+    processed.associate_x(
+        M_BN98 * unyt.Solar_Mass,
+        scatter=None,
+        comoving=True,
+        description=r"Halo Mass ($M_{\rm BN98}$)",
+    )
+    processed.associate_y(
+        (M_star / M_BN98) * unyt.dimensionless,
+        scatter=None,
+        comoving=True,
+        description=r"Galaxy Stellar Mass / Halo Mass ($M_* / M_{\rm BN98}$)",
+    )
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_redshift(z)
+    processed.associate_plot_as(plot_as)
+    processed.associate_cosmology(cosmology)
 
-output_path = f"{output_directory}/{output_filename}"
+    output_path = f"{output_directory}/{output_filename}"
 
-if os.path.exists(output_path):
-    os.remove(output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
 
-processed.write(filename=output_path)
+    processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -1,0 +1,76 @@
+from velociraptor.observations.objects import ObservationalData
+from velociraptor.fitting_formulae.smhmr import behroozi_2019_raw
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmology
+h_sim = cosmology.h
+
+output_filename = "Behroozi2019RatioStellar.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+# Redshift at which to plot the data
+redshift = 0.0
+
+M_vir = np.logspace(7, 15, 512)
+
+# Note that the function below actually takes M_{vir, peak}, and we are
+# ignoring this fact
+M_star = behroozi_2019_raw(redshift, M_vir)
+
+# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
+M_200 = M_vir / 1.2
+
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html"
+    "Median Fit to the raw data including both satellites and centrals."
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
+    "spherical overdensity definition"
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
+    "Shows the ratio between stellar mass and halo mass as a function of stellar mass."
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
+plot_as = "line"
+h = h_sim
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_star * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass",
+)
+processed.associate_y(
+    (M_star / M_200) * unyt.dimensionless,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{200, {\rm crit}}$)",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -13,66 +13,69 @@ with open(sys.argv[1], "r") as handle:
 # Cosmology
 h_sim = cosmology.h
 
-output_filename = "Behroozi2019RatioStellar.hdf5"
-output_directory = "../"
+# Redshifts at which to plot the data
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 
-if not os.path.exists(output_directory):
-    os.mkdir(output_directory)
+# Create and save data for each z in redshifts
+for z in redshifts:
 
-# Redshift at which to plot the data
-redshift = 0.0
+    output_filename = f"Behroozi2019RatioStellar_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_directory = "../"
 
-M_vir = np.logspace(9, 15, 512)
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
 
-# Note that the function below actually takes M_{vir, peak}, and we are
-# ignoring this fact
-M_star = behroozi_2019_raw(redshift, M_vir)
+    M_BN98 = np.logspace(9, 15, 512)
 
-# Correct M_vir --> M_200 (fit from EAGLE cosmology - cosmology dependence is very weak)
-M_200 = M_vir / 1.2
+    # Note that the function below actually takes M_{BN98, peak}, and we are
+    # ignoring this fact
+    M_star = behroozi_2019_raw(z, M_BN98)
 
-# Meta-data
-comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html. "
-    "Median fit to the raw data for centrals (i.e. excluding satellites). "
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-    "spherical overdensity definition. "
-    "The fitting function does not include the intrahalo light contribution to the "
-    "stellar mass. "
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
-    "Shows the ratio between stellar mass and halo mass as a function of stellar mass."
-)
-citation = "Behroozi et al. (2019)"
-bibcode = "2019MNRAS.488.3143B"
-name = "Fit to the stellar mass - halo mass relation at z={:.1}".format(redshift)
-plot_as = "line"
-h = h_sim
+    # Meta-data
+    comment = (
+        "The data is taken from https://www.peterbehroozi.com/data.html. "
+        "Median fit to the raw data for centrals (i.e. excluding satellites). "
+        "The stellar mass is the true stellar mass (i.e. w/o observational "
+        "corrections). "
+        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+        "spherical overdensity definition. "
+        "The fitting function does not include the intrahalo light contribution to the "
+        "stellar mass. "
+        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+        "n_s=0.96. "
+        "Shows the ratio between stellar mass and halo mass as a function of stellar "
+        "mass. "
+    )
+    citation = "Behroozi et al. (2019)"
+    bibcode = "2019MNRAS.488.3143B"
+    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
+    plot_as = "line"
+    h = h_sim
 
-# Write everything
-processed = ObservationalData()
-processed.associate_x(
-    M_star * unyt.Solar_Mass,
-    scatter=None,
-    comoving=True,
-    description="Galaxy Stellar Mass",
-)
-processed.associate_y(
-    (M_star / M_200) * unyt.dimensionless,
-    scatter=None,
-    comoving=True,
-    description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{200, {\rm crit}}$)",
-)
-processed.associate_citation(citation, bibcode)
-processed.associate_name(name)
-processed.associate_comment(comment)
-processed.associate_redshift(redshift)
-processed.associate_plot_as(plot_as)
-processed.associate_cosmology(cosmology)
+    # Write everything
+    processed = ObservationalData()
+    processed.associate_x(
+        M_star * unyt.Solar_Mass,
+        scatter=None,
+        comoving=True,
+        description="Galaxy Stellar Mass",
+    )
+    processed.associate_y(
+        (M_star / M_BN98) * unyt.dimensionless,
+        scatter=None,
+        comoving=True,
+        description=r"Galaxy Stellar Mass / Halo Mass ($M_* / M_{\rm BN98}$)",
+    )
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_redshift(z)
+    processed.associate_plot_as(plot_as)
+    processed.associate_cosmology(cosmology)
 
-output_path = f"{output_directory}/{output_filename}"
+    output_path = f"{output_directory}/{output_filename}"
 
-if os.path.exists(output_path):
-    os.remove(output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
 
-processed.write(filename=output_path)
+    processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -33,15 +33,15 @@ M_200 = M_vir / 1.2
 
 # Meta-data
 comment = (
-    "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median fit to the raw data for centrals (i.e. excluding satellites)"
-    "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
-    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
-    "spherical overdensity definition"
-    "The fitting function does not include the intrahalo light contribution to the"
-    "stellar mass"
-    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
-    "Shows the ratio between stellar mass and halo mass as a function of stellar mass"
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96. "
+    "Shows the ratio between stellar mass and halo mass as a function of stellar mass."
 )
 citation = "Behroozi et al. (2019)"
 bibcode = "2019MNRAS.488.3143B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -22,7 +22,7 @@ if not os.path.exists(output_directory):
 # Redshift at which to plot the data
 redshift = 0.0
 
-M_vir = np.logspace(7, 15, 512)
+M_vir = np.logspace(9, 15, 512)
 
 # Note that the function below actually takes M_{vir, peak}, and we are
 # ignoring this fact
@@ -34,12 +34,14 @@ M_200 = M_vir / 1.2
 # Meta-data
 comment = (
     "The data is taken from https://www.peterbehroozi.com/data.html"
-    "Median Fit to the raw data including both satellites and centrals."
+    "Median fit to the raw data for centrals (i.e. excluding satellites)"
     "The stellar mass is the true stellar mass (i.e. w/o observational corrections)"
     "The halo mass is the peak halo mass that follows the Bryan & Norman (1998)"
     "spherical overdensity definition"
+    "The fitting function does not include the intrahalo light contribution to the"
+    "stellar mass"
     "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, n_s=0.96"
-    "Shows the ratio between stellar mass and halo mass as a function of stellar mass."
+    "Shows the ratio between stellar mass and halo mass as a function of stellar mass"
 )
 citation = "Behroozi et al. (2019)"
 bibcode = "2019MNRAS.488.3143B"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -19,7 +19,7 @@ redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 # Create and save data for each z in redshifts
 for z in redshifts:
 
-    output_filename = f"Behroozi2019RatioStellar_{f'z{z:.1f}'.replace('.', 'p')}.hdf5"
+    output_filename = f"Behroozi2019RatioStellar_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
     output_directory = "../"
 
     if not os.path.exists(output_directory):
@@ -64,7 +64,7 @@ for z in redshifts:
         (M_star / M_BN98) * unyt.dimensionless,
         scatter=None,
         comoving=True,
-        description=r"Galaxy Stellar Mass / Halo Mass ($M_* / M_{\rm BN98}$)",
+        description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{\\rm BN98}$)",
     )
     processed.associate_citation(citation, bibcode)
     processed.associate_name(name)


### PR DESCRIPTION
Adding Behroozi 2019 StellarMassHaloMass data.

**Note that**
- The three new scripts make use of the _velociraptor-library function_ `behroozi_2019_raw()`, which is currently not part of the master branch, but rather belongs to [this pull request](https://github.com/SWIFTSIM/velociraptor-python/pull/26). 
- The conversion factor of **1.2** in the new scripts is only valid for **z=0**. The conversion factor connects `M_vir` (what is passed to `behroozi_2019_raw()`) to `M_200` (what is plotted).
- As the next step, we need to agree on 
  1. What to do with the conversion factor for `z>0`. The suggestion was to make a separate plot(s) with `M_vir` in place of `M_200`. Then the conversion factor is no longer needed.
  2. The way to produce Behroozi 2019 high-z data in addition to z=0 data without having to edit some files and rerun `convert.sh` several times.
 @MatthieuSchaller  suggested inserting a loop over `z` in these three new scripts, which will make them generate multiple .hdf5 files (at various z) and require running `convert.sh` just once.
- I haven't done anything yet regarding the above two suggestions, because I don't want to complicate this PR too much before I receive any feedback.