### PR TITLE
Multi-redshift data in a single file

### DIFF
--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -20,9 +20,11 @@ redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 # Halo masses
 M_BN98 = np.logspace(9, 15, 512)
+# Duplicate M_BN98 for all z
+M_BN98_arr = np.array([M_BN98 for _ in redshifts])
 
 # Stellar masses (for each z in redshifts)
-M_star = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
+M_star_arr = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
 
 output_filename = "Behroozi2019.hdf5"
 output_directory = "../"
@@ -53,13 +55,13 @@ h = h_sim
 # Write everything
 processed = ObservationalData()
 processed.associate_x(
-    M_BN98 * unyt.Solar_Mass,
+    M_BN98_arr * unyt.Solar_Mass,
     scatter=None,
     comoving=True,
     description="Halo Mass ($M_{\\rm BN98}$)",
 )
 processed.associate_y(
-    M_star * unyt.Solar_Mass,
+    M_star_arr * unyt.Solar_Mass,
     scatter=None,
     comoving=True,
     description="Galaxy Stellar Mass",

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -14,67 +14,66 @@ with open(sys.argv[1], "r") as handle:
 h_sim = cosmology.h
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
-# Create and save data for each z in redshifts
-for z in redshifts:
+# Halo masses
+M_BN98 = np.logspace(9, 15, 512)
 
-    output_filename = f"Behroozi2019_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
-    output_directory = "../"
+# Stellar masses (for each z in redshifts)
+M_star = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
 
-    if not os.path.exists(output_directory):
-        os.mkdir(output_directory)
+output_filename = "Behroozi2019.hdf5"
+output_directory = "../"
 
-    M_BN98 = np.logspace(9, 15, 512)
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
 
-    # Note that the function below actually takes M_{BN98, peak}, and we are
-    # ignoring this fact
-    M_star = behroozi_2019_raw(z, M_BN98)
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational "
+    "corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+    "n_s=0.96. "
+    "Shows the stellar mass as a function halo mass."
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = f"Fit to the stellar mass - halo mass relation at z=[{redshift_header_info:s}]"
+plot_as = "line"
+h = h_sim
 
-    # Meta-data
-    comment = (
-        "The data is taken from https://www.peterbehroozi.com/data.html. "
-        "Median fit to the raw data for centrals (i.e. excluding satellites). "
-        "The stellar mass is the true stellar mass (i.e. w/o observational "
-        "corrections). "
-        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-        "spherical overdensity definition. "
-        "The fitting function does not include the intrahalo light contribution to the "
-        "stellar mass. "
-        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
-        "n_s=0.96. "
-        "Shows the stellar mass as a function halo mass."
-    )
-    citation = "Behroozi et al. (2019)"
-    bibcode = "2019MNRAS.488.3143B"
-    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
-    plot_as = "line"
-    h = h_sim
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_BN98 * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Halo Mass ($M_{\\rm BN98}$)",
+)
+processed.associate_y(
+    M_star * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshifts)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
 
-    # Write everything
-    processed = ObservationalData()
-    processed.associate_x(
-        M_BN98 * unyt.Solar_Mass,
-        scatter=None,
-        comoving=True,
-        description="Halo Mass ($M_{\\rm BN98}$)",
-    )
-    processed.associate_y(
-        M_star * unyt.Solar_Mass,
-        scatter=None,
-        comoving=True,
-        description="Galaxy Stellar Mass",
-    )
-    processed.associate_citation(citation, bibcode)
-    processed.associate_name(name)
-    processed.associate_comment(comment)
-    processed.associate_redshift(z)
-    processed.associate_plot_as(plot_as)
-    processed.associate_cosmology(cosmology)
+output_path = f"{output_directory}/{output_filename}"
 
-    output_path = f"{output_directory}/{output_filename}"
+if os.path.exists(output_path):
+    os.remove(output_path)
 
-    if os.path.exists(output_path):
-        os.remove(output_path)
-
-    processed.write(filename=output_path)
+processed.write(filename=output_path)


### PR DESCRIPTION
**1. Why this PR**
As discussed some time ago with @JBorrow, it is best to have multi-z data in a single file (in place of many different files with the name patter `file_name_z???p???.hdf5`)

**2. What has been changed so far**
So far I only modified one script `Berhoozi2019.py`. If everything is fine there, I will apply these changes to the other scripts producing multi-z data.

**3. Example a multi-z .hdf5 file structure**

Affected fields are:

- attributes.name
- attributes.redshift
- y.values

```
Behroozi2019.hdf5
├cosmology
│ └9 attributes:
│   ├H0: 67.74
│   ├Neff: 3.046
│   ├Ob0: 0.0486
│   ├Ode0: 0.6910098821161554
│   ├Om0: 0.3075
│   ├Tcmb0: 2.7255
│   ├m_nu: [0.   0.   0.06]
│   ├m_nu_units: 'eV'
│   └name: 'Planck15'
├metadata
│ └6 attributes:
│   ├bibcode: '2019MNRAS.488.3143B'
│   ├citation: 'Behroozi et al. (2019)'
│   ├comment: 'The data is taken f...function halo mass.'
│   ├name: 'Fit to the stellar ...2.5, 3.0, 4.0, 5.0]'
│   ├plot_as: 'line'
│   └redshift: [0.  0.2 0.5 1.  1.5 2.  2.5 3.  4.  5. ]
├x
│ ├2 attributes:
│ │ ├comoving: True
│ │ └description: 'Halo Mass ($M_{\\rm BN98}$)'
│ └values [float64: 10 × 512]
│   └2 attributes:
│     ├unit_registry: void(b'\x80\x03\x7D\x71\x00\x2E')
│     └units: 'Msun'
└y
  ├2 attributes:
  │ ├comoving: True
  │ └description: 'Galaxy Stellar Mass'
  └values [float64: 10 × 512]
    └2 attributes:
      ├unit_registry: void(b'\x80\x03\x7D\x71\x00\x2E')
      └units: 'Msun'
```

