### PR TITLE
Make Berhoozi2019 & Eagle2015 data work with multi-z update

### DIFF
--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -66,7 +66,7 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+    # Choose \Delta z = 0.25 to cover the whole range in z
     redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -50,6 +50,7 @@ multi_z.associate_citation(citation, bibcode)
 multi_z.associate_name(name)
 multi_z.associate_comment(comment)
 multi_z.associate_cosmology(cosmology)
+multi_z.associate_maximum_number_of_returns(1)
 
 output_filename = "Behroozi2019.hdf5"
 output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -20,9 +20,11 @@ redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 # Halo masses
 M_BN98 = np.logspace(9, 15, 512)
+# Duplicate M_BN98 for all z
+M_BN98_arr = np.array([M_BN98 for _ in redshifts])
 
 # Stellar masses (for each z in redshifts)
-M_star = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
+M_star_arr = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
 
 output_filename = "Behroozi2019.hdf5"
 output_directory = "../"
@@ -53,13 +55,13 @@ h = h_sim
 # Write everything
 processed = ObservationalData()
 processed.associate_x(
-    M_BN98 * unyt.Solar_Mass,
+    M_BN98_arr * unyt.Solar_Mass,
     scatter=None,
     comoving=True,
     description="Halo Mass ($M_{\\rm BN98}$)",
 )
 processed.associate_y(
-    M_star * unyt.Solar_Mass,
+    M_star_arr * unyt.Solar_Mass,
     scatter=None,
     comoving=True,
     description="Galaxy Stellar Mass",

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -14,12 +14,12 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 # Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
-M_BN98 = np.logspace(10, 15, 512)
+M_BN98 = np.logspace(10.5, 15.0, 512)
 
 # Cosmology
 h_sim = cosmology.h
@@ -67,7 +67,7 @@ for z in redshifts:
     M_star = behroozi_2019_raw(z, M_BN98)
 
     # A fitting function gives us the data at any z. Hence, no need to have \Delta z
-    redshift_lower, redshift_upper = [z, z]
+    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(
         M_BN98 * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -14,12 +14,12 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
-# Halo masses
-M_BN98 = np.logspace(9, 15, 512)
+# Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
+M_BN98 = np.logspace(10, 15, 512)
 
 # Cosmology
 h_sim = cosmology.h

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -14,67 +14,66 @@ with open(sys.argv[1], "r") as handle:
 h_sim = cosmology.h
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
-# Create and save data for each z in redshifts
-for z in redshifts:
+# Halo masses
+M_BN98 = np.logspace(9, 15, 512)
 
-    output_filename = f"Behroozi2019_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
-    output_directory = "../"
+# Stellar masses (for each z in redshifts)
+M_star = np.array([behroozi_2019_raw(z, M_BN98) for z in redshifts])
 
-    if not os.path.exists(output_directory):
-        os.mkdir(output_directory)
+output_filename = "Behroozi2019.hdf5"
+output_directory = "../"
 
-    M_BN98 = np.logspace(9, 15, 512)
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
 
-    # Note that the function below actually takes M_{BN98, peak}, and we are
-    # ignoring this fact
-    M_star = behroozi_2019_raw(z, M_BN98)
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational "
+    "corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+    "n_s=0.96. "
+    "Shows the stellar mass as a function halo mass."
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = f"Fit to the stellar mass - halo mass relation at z=[{redshift_header_info:s}]"
+plot_as = "line"
+h = h_sim
 
-    # Meta-data
-    comment = (
-        "The data is taken from https://www.peterbehroozi.com/data.html. "
-        "Median fit to the raw data for centrals (i.e. excluding satellites). "
-        "The stellar mass is the true stellar mass (i.e. w/o observational "
-        "corrections). "
-        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-        "spherical overdensity definition. "
-        "The fitting function does not include the intrahalo light contribution to the "
-        "stellar mass. "
-        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
-        "n_s=0.96. "
-        "Shows the stellar mass as a function halo mass."
-    )
-    citation = "Behroozi et al. (2019)"
-    bibcode = "2019MNRAS.488.3143B"
-    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
-    plot_as = "line"
-    h = h_sim
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_BN98 * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Halo Mass ($M_{\\rm BN98}$)",
+)
+processed.associate_y(
+    M_star * unyt.Solar_Mass,
+    scatter=None,
+    comoving=True,
+    description="Galaxy Stellar Mass",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshifts)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
 
-    # Write everything
-    processed = ObservationalData()
-    processed.associate_x(
-        M_BN98 * unyt.Solar_Mass,
-        scatter=None,
-        comoving=True,
-        description="Halo Mass ($M_{\\rm BN98}$)",
-    )
-    processed.associate_y(
-        M_star * unyt.Solar_Mass,
-        scatter=None,
-        comoving=True,
-        description="Galaxy Stellar Mass",
-    )
-    processed.associate_citation(citation, bibcode)
-    processed.associate_name(name)
-    processed.associate_comment(comment)
-    processed.associate_redshift(z)
-    processed.associate_plot_as(plot_as)
-    processed.associate_cosmology(cosmology)
+output_path = f"{output_directory}/{output_filename}"
 
-    output_path = f"{output_directory}/{output_filename}"
+if os.path.exists(output_path):
+    os.remove(output_path)
 
-    if os.path.exists(output_path):
-        os.remove(output_path)
-
-    processed.write(filename=output_path)
+processed.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -14,7 +14,13 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+redshifts = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+
+# Valid redshift ranges for each z from above
+Delta_z = 0.5 * (redshifts[1:] - redshifts[:-1])
+redshifts_lower = np.append(0.10, Delta_z)
+redshifts_upper = np.append(Delta_z, 0.25)
+
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
@@ -58,7 +64,7 @@ output_directory = "../"
 if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
-for z in redshifts:
+for z, dz_lower, dz_upper in zip(redshifts, redshifts_lower, redshifts_upper):
 
     # Create a single observational-data instance at redshift z
     processed = ObservationalData()
@@ -66,8 +72,8 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # Choose \Delta z = 0.25 to cover the whole range in z
-    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
+    # Compute \Delta z
+    redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]
 
     processed.associate_x(
         M_BN98 * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -66,7 +66,7 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+    # Choose \Delta z = 0.25 to cover the whole range in z
     redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -1,4 +1,7 @@
-from velociraptor.observations.objects import ObservationalData
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
 from velociraptor.fitting_formulae.smhmr import behroozi_2019_raw
 
 import unyt
@@ -10,49 +13,61 @@ import sys
 with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
+# Redshifts at which to plot the data
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
+
+# Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
+M_BN98 = np.logspace(10, 15, 512)
+
 # Cosmology
 h_sim = cosmology.h
 
-# Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational "
+    "corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+    "n_s=0.96. "
+    "Shows the ratio between stellar mass and halo mass as a function of halo mass."
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = f"Fit to the stellar mass / halo mass - halo mass relation at z=[{redshift_header_info:s}]"
+plot_as = "line"
+h = h_sim
 
-# Create and save data for each z in redshifts
+# Store metadata at the top level
+multi_z = MultiRedshiftObservationalData()
+multi_z.associate_citation(citation, bibcode)
+multi_z.associate_name(name)
+multi_z.associate_comment(comment)
+multi_z.associate_cosmology(cosmology)
+
+output_filename = "Behroozi2019Ratio.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
 for z in redshifts:
 
-    output_filename = f"Behroozi2019Ratio_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
-    output_directory = "../"
+    # Create a single observational-data instance at redshift z
+    processed = ObservationalData()
 
-    if not os.path.exists(output_directory):
-        os.mkdir(output_directory)
-
-    M_BN98 = np.logspace(9, 15, 512)
-
-    # Note that the function below actually takes M_{BN98, peak}, and we are
-    # ignoring this fact
+    # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # Meta-data
-    comment = (
-        "The data is taken from https://www.peterbehroozi.com/data.html. "
-        "Median fit to the raw data for centrals (i.e. excluding satellites). "
-        "The stellar mass is the true stellar mass (i.e. w/o observational "
-        "corrections). "
-        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-        "spherical overdensity definition. "
-        "The fitting function does not include the intrahalo light contribution to the "
-        "stellar mass. "
-        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
-        "n_s=0.96. "
-        "Shows the ratio between stellar mass and halo mass as a function of halo mass."
-    )
-    citation = "Behroozi et al. (2019)"
-    bibcode = "2019MNRAS.488.3143B"
-    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
-    plot_as = "line"
-    h = h_sim
+    # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+    redshift_lower, redshift_upper = [z, z]
 
-    # Write everything
-    processed = ObservationalData()
     processed.associate_x(
         M_BN98 * unyt.Solar_Mass,
         scatter=None,
@@ -65,16 +80,15 @@ for z in redshifts:
         comoving=True,
         description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{\\rm BN98}$)",
     )
-    processed.associate_citation(citation, bibcode)
-    processed.associate_name(name)
-    processed.associate_comment(comment)
-    processed.associate_redshift(z)
+
+    processed.associate_redshift(z, redshift_lower, redshift_upper)
     processed.associate_plot_as(plot_as)
-    processed.associate_cosmology(cosmology)
 
-    output_path = f"{output_directory}/{output_filename}"
+    multi_z.associate_dataset(processed)
 
-    if os.path.exists(output_path):
-        os.remove(output_path)
+output_path = f"{output_directory}/{output_filename}"
 
-    processed.write(filename=output_path)
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+multi_z.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -14,12 +14,12 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 # Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
-M_BN98 = np.logspace(10, 15, 512)
+M_BN98 = np.logspace(10.5, 15.0, 512)
 
 # Cosmology
 h_sim = cosmology.h
@@ -67,7 +67,7 @@ for z in redshifts:
     M_star = behroozi_2019_raw(z, M_BN98)
 
     # A fitting function gives us the data at any z. Hence, no need to have \Delta z
-    redshift_lower, redshift_upper = [z, z]
+    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(
         M_BN98 * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -50,6 +50,7 @@ multi_z.associate_citation(citation, bibcode)
 multi_z.associate_name(name)
 multi_z.associate_comment(comment)
 multi_z.associate_cosmology(cosmology)
+multi_z.associate_maximum_number_of_returns(1)
 
 output_filename = "Behroozi2019Ratio.hdf5"
 output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019Ratio.py
@@ -14,7 +14,13 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+redshifts = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+
+# Valid redshift ranges for each z from above
+Delta_z = 0.5 * (redshifts[1:] - redshifts[:-1])
+redshifts_lower = np.append(0.10, Delta_z)
+redshifts_upper = np.append(Delta_z, 0.25)
+
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
@@ -58,7 +64,7 @@ output_directory = "../"
 if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
-for z in redshifts:
+for z, dz_lower, dz_upper in zip(redshifts, redshifts_lower, redshifts_upper):
 
     # Create a single observational-data instance at redshift z
     processed = ObservationalData()
@@ -66,8 +72,8 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # Choose \Delta z = 0.25 to cover the whole range in z
-    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
+    # Compute \Delta z
+    redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]
 
     processed.associate_x(
         M_BN98 * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -14,7 +14,13 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+redshifts = np.array([0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0])
+
+# Valid redshift ranges for each z from above
+Delta_z = 0.5 * (redshifts[1:] - redshifts[:-1])
+redshifts_lower = np.append(0.10, Delta_z)
+redshifts_upper = np.append(Delta_z, 0.25)
+
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
@@ -59,7 +65,7 @@ output_directory = "../"
 if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
-for z in redshifts:
+for z, dz_lower, dz_upper in zip(redshifts, redshifts_lower, redshifts_upper):
 
     # Create a single observational-data instance at redshift z
     processed = ObservationalData()
@@ -67,8 +73,8 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # Choose \Delta z = 0.25 to cover the whole range in z
-    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
+    # Compute \Delta z
+    redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]
 
     processed.associate_x(
         M_star * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -1,4 +1,7 @@
-from velociraptor.observations.objects import ObservationalData
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
 from velociraptor.fitting_formulae.smhmr import behroozi_2019_raw
 
 import unyt
@@ -10,50 +13,62 @@ import sys
 with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
+# Redshifts at which to plot the data
+redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
+
+# Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
+M_BN98 = np.logspace(10, 15, 512)
+
 # Cosmology
 h_sim = cosmology.h
 
-# Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Meta-data
+comment = (
+    "The data is taken from https://www.peterbehroozi.com/data.html. "
+    "Median fit to the raw data for centrals (i.e. excluding satellites). "
+    "The stellar mass is the true stellar mass (i.e. w/o observational "
+    "corrections). "
+    "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
+    "spherical overdensity definition. "
+    "The fitting function does not include the intrahalo light contribution to the "
+    "stellar mass. "
+    "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
+    "n_s=0.96. "
+    "Shows the ratio between stellar mass and halo mass as a function of stellar "
+    "mass. "
+)
+citation = "Behroozi et al. (2019)"
+bibcode = "2019MNRAS.488.3143B"
+name = f"Fit to the stellar mass / halo mass - stellar mass relation at z=[{redshift_header_info:s}]"
+plot_as = "line"
+h = h_sim
 
-# Create and save data for each z in redshifts
+# Store metadata at the top level
+multi_z = MultiRedshiftObservationalData()
+multi_z.associate_citation(citation, bibcode)
+multi_z.associate_name(name)
+multi_z.associate_comment(comment)
+multi_z.associate_cosmology(cosmology)
+
+output_filename = "Behroozi2019RatioStellar.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
 for z in redshifts:
 
-    output_filename = f"Behroozi2019RatioStellar_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
-    output_directory = "../"
+    # Create a single observational-data instance at redshift z
+    processed = ObservationalData()
 
-    if not os.path.exists(output_directory):
-        os.mkdir(output_directory)
-
-    M_BN98 = np.logspace(9, 15, 512)
-
-    # Note that the function below actually takes M_{BN98, peak}, and we are
-    # ignoring this fact
+    # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # Meta-data
-    comment = (
-        "The data is taken from https://www.peterbehroozi.com/data.html. "
-        "Median fit to the raw data for centrals (i.e. excluding satellites). "
-        "The stellar mass is the true stellar mass (i.e. w/o observational "
-        "corrections). "
-        "The halo mass is the peak halo mass that follows the Bryan & Norman (1998) "
-        "spherical overdensity definition. "
-        "The fitting function does not include the intrahalo light contribution to the "
-        "stellar mass. "
-        "Cosmology: Omega_m=0.307, Omega_lambda=0.693, h=0.678, sigma_8=0.823, "
-        "n_s=0.96. "
-        "Shows the ratio between stellar mass and halo mass as a function of stellar "
-        "mass. "
-    )
-    citation = "Behroozi et al. (2019)"
-    bibcode = "2019MNRAS.488.3143B"
-    name = "Fit to the stellar mass - halo mass relation at z={:.1f}".format(z)
-    plot_as = "line"
-    h = h_sim
+    # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+    redshift_lower, redshift_upper = [z, z]
 
-    # Write everything
-    processed = ObservationalData()
     processed.associate_x(
         M_star * unyt.Solar_Mass,
         scatter=None,
@@ -66,16 +81,15 @@ for z in redshifts:
         comoving=True,
         description="Galaxy Stellar Mass / Halo Mass ($M_* / M_{\\rm BN98}$)",
     )
-    processed.associate_citation(citation, bibcode)
-    processed.associate_name(name)
-    processed.associate_comment(comment)
-    processed.associate_redshift(z)
+
+    processed.associate_redshift(z, redshift_lower, redshift_upper)
     processed.associate_plot_as(plot_as)
-    processed.associate_cosmology(cosmology)
 
-    output_path = f"{output_directory}/{output_filename}"
+    multi_z.associate_dataset(processed)
 
-    if os.path.exists(output_path):
-        os.remove(output_path)
+output_path = f"{output_directory}/{output_filename}"
 
-    processed.write(filename=output_path)
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+multi_z.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -51,6 +51,7 @@ multi_z.associate_citation(citation, bibcode)
 multi_z.associate_name(name)
 multi_z.associate_comment(comment)
 multi_z.associate_cosmology(cosmology)
+multi_z.associate_maximum_number_of_returns(1)
 
 output_filename = "Behroozi2019RatioStellar.hdf5"
 output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -67,7 +67,7 @@ for z in redshifts:
     # Stellar masses (for the given halo masses, at redshift z)
     M_star = behroozi_2019_raw(z, M_BN98)
 
-    # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+    # Choose \Delta z = 0.25 to cover the whole range in z
     redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019RatioStellar.py
@@ -14,12 +14,12 @@ with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
 # Redshifts at which to plot the data
-redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+redshifts = [0.0, 0.2, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
 # Create the formatted version of the above array
 redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 # Halo masses (Berhoozi data were fitted in the range [10**10.5, 10**15] Msun)
-M_BN98 = np.logspace(10, 15, 512)
+M_BN98 = np.logspace(10.5, 15.0, 512)
 
 # Cosmology
 h_sim = cosmology.h
@@ -68,7 +68,7 @@ for z in redshifts:
     M_star = behroozi_2019_raw(z, M_BN98)
 
     # A fitting function gives us the data at any z. Hence, no need to have \Delta z
-    redshift_lower, redshift_upper = [z, z]
+    redshift_lower, redshift_upper = [z - 0.25, z + 0.25]
 
     processed.associate_x(
         M_star * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLE.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLE.py
@@ -1,4 +1,7 @@
-from velociraptor.observations.objects import ObservationalData
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
 
 import unyt
 import numpy as np
@@ -14,18 +17,46 @@ h_sim = cosmology.h
 
 # Redshifts at which to plot the data
 redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 haloes = ["M200", "MBN98"]
 latex_names = ["$M_{200, {\\rm crit}}$", "$M_{\\rm BN98}$"]
 
-# Create and save data for each halo definition and z in redshifts
 for halo, latex_name in zip(haloes, latex_names):
+
+    # Meta-data
+    comment = (
+        "Medians obtained directly from the subfind catalogs. "
+        "Central galaxies only. Halos with 0 stellar mass included. "
+        f"Halo mass definition is {halo:s}. "
+        "Stellar masses use a 30kpc spherical aperture. "
+        "No cosmology correction needed."
+    )
+    citation = "EAGLE - L100N1504"
+    bibcode = "2015MNRAS.446..521S"
+    name = f"Galaxy Stellar Mass - Halo Mass relation at z=[{redshift_header_info:s}]"
+    plot_as = "line"
+    h = h_sim
+
+    # Store metadata at the top level
+
+    multi_z = MultiRedshiftObservationalData()
+    multi_z.associate_citation(citation, bibcode)
+    multi_z.associate_name(name)
+    multi_z.associate_comment(comment)
+    multi_z.associate_cosmology(cosmology)
+
+    output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}.hdf5"
+    output_directory = "../"
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
     for z in redshifts:
 
-        output_filename = (
-            f"Schaye2015_Ref_100_{f'{halo:s}'}_{f'z{z:07.3f}'.replace('.', 'p')}.hdf5"
-        )
-        output_directory = "../"
+        # Create a single observational-data instance at redshift z
+        processed = ObservationalData()
 
         if not os.path.exists(output_directory):
             os.mkdir(output_directory)
@@ -41,23 +72,9 @@ for halo, latex_name in zip(haloes, latex_names):
         # Define the scatter as offset from the mean value
         y_scatter = unyt.unyt_array((M_star_50 - M_star_16, M_star_84 - M_star_50))
 
-        # Meta-data
-        comment = (
-            "Medians obtained directly from the subfind catalogs. "
-            "Central galaxies only. Halos with 0 stellar mass included. "
-            f"Halo mass definition is {halo:s}. "
-            "Stellar masses use a 30kpc spherical aperture. "
-            "No cosmology correction needed."
-        )
-        citation = "EAGLE - L100N1504"
-        bibcode = "2015MNRAS.446..521S"
-        name = f"Galaxy Stellar Mass - Halo Mass relation at z={f'{z:3.1f}'}."
-        plot_as = "line"
-        redshift = z
-        h = h_sim
+        # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+        redshift_lower, redshift_upper = [z, z]
 
-        # Write everything
-        processed = ObservationalData()
         processed.associate_x(
             M_halo,
             scatter=None,
@@ -70,16 +87,15 @@ for halo, latex_name in zip(haloes, latex_names):
             comoving=True,
             description="Galaxy Stellar Mass (30kpc, 3D)",
         )
-        processed.associate_citation(citation, bibcode)
-        processed.associate_name(name)
-        processed.associate_comment(comment)
-        processed.associate_redshift(redshift)
+
+        processed.associate_redshift(z, redshift_lower, redshift_upper)
         processed.associate_plot_as(plot_as)
-        processed.associate_cosmology(cosmology)
 
-        output_path = f"{output_directory}/{output_filename}"
+        multi_z.associate_dataset(processed)
 
-        if os.path.exists(output_path):
-            os.remove(output_path)
+    output_path = f"{output_directory}/{output_filename}"
 
-        processed.write(filename=output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    multi_z.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLE.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLE.py
@@ -46,6 +46,7 @@ for halo, latex_name in zip(haloes, latex_names):
     multi_z.associate_name(name)
     multi_z.associate_comment(comment)
     multi_z.associate_cosmology(cosmology)
+    multi_z.associate_maximum_number_of_returns(1)
 
     output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}.hdf5"
     output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatio.py
@@ -46,6 +46,7 @@ for halo, latex_name in zip(haloes, latex_names):
     multi_z.associate_name(name)
     multi_z.associate_comment(comment)
     multi_z.associate_cosmology(cosmology)
+    multi_z.associate_maximum_number_of_returns(1)
 
     output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_Ratio.hdf5"
     output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatio.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatio.py
@@ -1,4 +1,7 @@
-from velociraptor.observations.objects import ObservationalData
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
 
 import unyt
 import numpy as np
@@ -14,16 +17,46 @@ h_sim = cosmology.h
 
 # Redshifts at which to plot the data
 redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 haloes = ["M200", "MBN98"]
 latex_names = ["$M_{200, {\\rm crit}}$", "$M_{\\rm BN98}$"]
 
-# Create and save data for each halo definition and z in redshifts
 for halo, latex_name in zip(haloes, latex_names):
+
+    # Meta-data
+    comment = (
+        "Medians obtained directly from the subfind catalogs. "
+        "Central galaxies only. Halos with 0 stellar mass included. "
+        f"Halo mass definition is {halo:s}. "
+        "Stellar masses use a 30kpc spherical aperture. "
+        "No cosmology correction needed."
+    )
+    citation = "EAGLE - L100N1504"
+    bibcode = "2015MNRAS.446..521S"
+    name = f"Galaxy Stellar Mass / Halo mass - Halo Mass relation at z at z=[{redshift_header_info:s}]"
+    plot_as = "line"
+    h = h_sim
+
+    # Store metadata at the top level
+
+    multi_z = MultiRedshiftObservationalData()
+    multi_z.associate_citation(citation, bibcode)
+    multi_z.associate_name(name)
+    multi_z.associate_comment(comment)
+    multi_z.associate_cosmology(cosmology)
+
+    output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_Ratio.hdf5"
+    output_directory = "../"
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
     for z in redshifts:
 
-        output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_{f'z{z:07.3f}'.replace('.', 'p')}_Ratio.hdf5"
-        output_directory = "../"
+        # Create a single observational-data instance at redshift z
+        processed = ObservationalData()
 
         if not os.path.exists(output_directory):
             os.mkdir(output_directory)
@@ -31,6 +64,7 @@ for halo, latex_name in zip(haloes, latex_names):
         data = np.loadtxt(
             f"../raw/EAGLE_SMHM_{f'{halo:s}'}_ratio_L100N1504_{f'z{z:03.1f}'.replace('.', 'p')}.txt"
         )
+
         M_halo = unyt.unyt_array(data[:, 0], units=unyt.Solar_Mass)
         M_star_ratio_16 = unyt.unyt_array(data[:, 1], units=unyt.dimensionless)
         M_star_ratio_50 = unyt.unyt_array(data[:, 2], units=unyt.dimensionless)
@@ -41,25 +75,9 @@ for halo, latex_name in zip(haloes, latex_names):
             (M_star_ratio_50 - M_star_ratio_16, M_star_ratio_84 - M_star_ratio_50)
         )
 
-        # Meta-data
-        comment = (
-            "Medians obtained directly from the subfind catalogs. "
-            "Central galaxies only. Halos with 0 stellar mass included. "
-            f"Halo mass definition is {halo:s}. "
-            "Stellar masses use a 30kpc spherical aperture. "
-            "No cosmology correction needed."
-        )
-        citation = "EAGLE - L100N1504"
-        bibcode = "2015MNRAS.446..521S"
-        name = (
-            f"Galaxy Stellar Mass / Halo mass - Halo Mass relation at z={f'{z:3.1f}'}."
-        )
-        plot_as = "line"
-        redshift = z
-        h = h_sim
+        # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+        redshift_lower, redshift_upper = [z, z]
 
-        # Write everything
-        processed = ObservationalData()
         processed.associate_x(
             M_halo,
             scatter=None,
@@ -72,16 +90,15 @@ for halo, latex_name in zip(haloes, latex_names):
             comoving=True,
             description="Galaxy Stellar Mass (30kpc, 3D) / Halo Mass ({latex_name:s})",
         )
-        processed.associate_citation(citation, bibcode)
-        processed.associate_name(name)
-        processed.associate_comment(comment)
-        processed.associate_redshift(redshift)
+
+        processed.associate_redshift(z, redshift_lower, redshift_upper)
         processed.associate_plot_as(plot_as)
-        processed.associate_cosmology(cosmology)
 
-        output_path = f"{output_directory}/{output_filename}"
+        multi_z.associate_dataset(processed)
 
-        if os.path.exists(output_path):
-            os.remove(output_path)
+    output_path = f"{output_directory}/{output_filename}"
 
-        processed.write(filename=output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    multi_z.write(filename=output_path)

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatioStellar.py
@@ -46,6 +46,7 @@ for halo, latex_name in zip(haloes, latex_names):
     multi_z.associate_name(name)
     multi_z.associate_comment(comment)
     multi_z.associate_cosmology(cosmology)
+    multi_z.associate_maximum_number_of_returns(1)
 
     output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_RatioStellar.hdf5"
     output_directory = "../"

--- a/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatioStellar.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertEAGLERatioStellar.py
@@ -1,4 +1,7 @@
-from velociraptor.observations.objects import ObservationalData
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
 
 import unyt
 import numpy as np
@@ -14,16 +17,46 @@ h_sim = cosmology.h
 
 # Redshifts at which to plot the data
 redshifts = [0.0, 0.2, 0.5, 1.0, 2.0, 3.0, 4.0, 5.0]
+# Create the formatted version of the above array
+redshift_header_info = ", ".join([f"{z:.1f}" for z in redshifts])
 
 haloes = ["M200", "MBN98"]
 latex_names = ["$M_{200, {\\rm crit}}$", "$M_{\\rm BN98}$"]
 
-# Create and save data for each halo definition and z in redshifts
 for halo, latex_name in zip(haloes, latex_names):
+
+    # Meta-data
+    comment = (
+        "Medians obtained directly from the subfind catalogs. "
+        "Central galaxies only. Halos with 0 stellar mass included. "
+        f"Halo mass definition is {halo:s}. "
+        "Stellar masses use a 30kpc spherical aperture. "
+        "No cosmology correction needed."
+    )
+    citation = "EAGLE - L100N1504"
+    bibcode = "2015MNRAS.446..521S"
+    name = f"Galaxy Stellar Mass / Halo mass - Stellar Mass relation at z at z=[{redshift_header_info:s}]"
+    plot_as = "line"
+    h = h_sim
+
+    # Store metadata at the top level
+
+    multi_z = MultiRedshiftObservationalData()
+    multi_z.associate_citation(citation, bibcode)
+    multi_z.associate_name(name)
+    multi_z.associate_comment(comment)
+    multi_z.associate_cosmology(cosmology)
+
+    output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_RatioStellar.hdf5"
+    output_directory = "../"
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
     for z in redshifts:
 
-        output_filename = f"Schaye2015_Ref_100_{f'{halo:s}'}_{f'z{z:07.3f}'.replace('.', 'p')}_RatioStellar.hdf5"
-        output_directory = "../"
+        # Create a single observational-data instance at redshift z
+        processed = ObservationalData()
 
         if not os.path.exists(output_directory):
             os.mkdir(output_directory)
@@ -31,6 +64,7 @@ for halo, latex_name in zip(haloes, latex_names):
         data = np.loadtxt(
             f"../raw/EAGLE_SMHM_{f'{halo:s}'}_ratio_stellar_L100N1504_{f'z{z:03.1f}'.replace('.', 'p')}.txt"
         )
+
         M_star = unyt.unyt_array(data[:, 0], units=unyt.Solar_Mass)
         M_star_ratio_16 = unyt.unyt_array(data[:, 1], units=unyt.dimensionless)
         M_star_ratio_50 = unyt.unyt_array(data[:, 2], units=unyt.dimensionless)
@@ -41,23 +75,9 @@ for halo, latex_name in zip(haloes, latex_names):
             (M_star_ratio_50 - M_star_ratio_16, M_star_ratio_84 - M_star_ratio_50)
         )
 
-        # Meta-data
-        comment = (
-            "Medians obtained directly from the subfind catalogs. "
-            "Central galaxies only. Halos with 0 stellar mass included. "
-            f"Halo mass definition is {halo:s}. "
-            "Stellar masses use a 30kpc spherical aperture. "
-            "No cosmology correction needed."
-        )
-        citation = "EAGLE - L100N1504"
-        bibcode = "2015MNRAS.446..521S"
-        name = f"Galaxy Stellar Mass / Halo mass - Stellar Mass relation at z={f'{z:3.1f}'}."
-        plot_as = "line"
-        redshift = z
-        h = h_sim
+        # A fitting function gives us the data at any z. Hence, no need to have \Delta z
+        redshift_lower, redshift_upper = [z, z]
 
-        # Write everything
-        processed = ObservationalData()
         processed.associate_x(
             M_star,
             scatter=None,
@@ -70,16 +90,15 @@ for halo, latex_name in zip(haloes, latex_names):
             comoving=True,
             description="Galaxy Stellar Mass (30kpc, 3D) / Halo Mass ({latex_name:s})",
         )
-        processed.associate_citation(citation, bibcode)
-        processed.associate_name(name)
-        processed.associate_comment(comment)
-        processed.associate_redshift(redshift)
+
+        processed.associate_redshift(z, redshift_lower, redshift_upper)
         processed.associate_plot_as(plot_as)
-        processed.associate_cosmology(cosmology)
 
-        output_path = f"{output_directory}/{output_filename}"
+        multi_z.associate_dataset(processed)
 
-        if os.path.exists(output_path):
-            os.remove(output_path)
+    output_path = f"{output_directory}/{output_filename}"
 
-        processed.write(filename=output_path)
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    multi_z.write(filename=output_path)


### PR DESCRIPTION
We already have **Berhoozi2019** and **Eagle2015** available at various redshifts.

However, following @JBorrow latest update to VR library, these data now needs to be arranged in an hdf5 file in a different way (so that VR can access the data at different redshifts **automatically**)

This is what this PR is exactly for.