### PR TITLE
First version of CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,8 +31,8 @@ jobs:
 
       # Runs the conversion script for the first time
       - name: First conversion
-        run: ./convert.sh
+        run: bash convert.sh
         
       # Runs the conversion script again to check proper output file cleanup
       - name: Second conversion
-        run: ./convert.sh
+        run: bash convert.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Installs required Python modules
+      - name: Install Python modules
+        run: python3 -m pip install velociraptor matplotlib
+
+      # Runs the conversion script for the first time
+      - name: First conversion
+        run: ./convert.sh
+        
+      # Runs the conversion script again to check proper output file cleanup
+      - name: Second conversion
+        run: ./convert.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,4 +53,4 @@ jobs:
 
       # Runs the formatting script
       - name: Formatting
-        run: bash format.sh
+        run: bash format.sh --check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  build:
+  # Conversion check
+  conversion:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -36,3 +36,21 @@ jobs:
       # Runs the conversion script again to check proper output file cleanup
       - name: Second conversion
         run: bash convert.sh
+
+  # Formatting check
+  formatting:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Installs required Python modules
+      - name: Install Python modules
+        run: python3 -m pip install black
+
+      # Runs the formatting script
+      - name: Formatting
+        run: bash format.sh


### PR DESCRIPTION
This pull request adds CI to the repository (again?) using GitHub Actions. The new action workflow first installs the Python module dependencies (currently `velociraptor` and `matplotlib`) and then runs the conversion script twice. The second run is necessary to check if all conversion scripts properly clean up old output files. As an example why this is useful, the current `master` does not pass the test for exactly that reason (see #96 and #97).
The CI runs for every push to `master` and every pull request for `master`. To test it, it currently runs for an artificial pull request in my own fork, see https://github.com/bwvdnbro/velociraptor-comparison-data/actions/runs/1071776187.

Todo:
- [x] Add formatting check