### PR TITLE
Replace 'means' with 'medians' in Saintonge2017 data

### DIFF
--- a/data/GalaxyH2Fractions/conversion/convertSaintonge2017.py
+++ b/data/GalaxyH2Fractions/conversion/convertSaintonge2017.py
@@ -71,15 +71,16 @@ filetag = ["abcissa_M_star", "abcissa_mu_star", "abcissa_NUV_minus_r", "abcissa_
 for i in range(len(tables)):
     processed = ObservationalData()
 
+    # Take values from the 'Binning' method in Table 5 from Saintonge et al. (2017)
     if i != 2:
-        x_vals = 10 ** tables[i][:, 0] * units[i]
+        x_vals = 10 ** tables[i][:, 4] * units[i]
     else:
-        x_vals = tables[i][:, 0] * units[i]
+        x_vals = tables[i][:, 4] * units[i]
 
-    fh2 = 10 ** tables[i][:, 2] * unitless
+    fh2 = 10 ** tables[i][:, 6] * unitless
 
-    fh2_plus_err = (10 ** (tables[i][:, 2] + tables[i][:, 3]) * unitless) - fh2
-    fh2_minus_err = fh2 - (10 ** (tables[i][:, 2] - tables[i][:, 3]) * unitless)
+    fh2_plus_err = (10 ** (tables[i][:, 6] + tables[i][:, 7]) * unitless) - fh2
+    fh2_minus_err = fh2 - (10 ** (tables[i][:, 6] - tables[i][:, 7]) * unitless)
     fh2_err = np.row_stack([fh2_minus_err, fh2_plus_err])
 
     processed.associate_x(x_vals, scatter=None, comoving=False, description=labels[i])


### PR DESCRIPTION
Replace 'means' with 'medians' in **Saintonge2017** data

- See table 5 on page 13 in https://arxiv.org/pdf/1710.02157.pdf and discussion on page 11

- We want Saintonge2017's medians (in the paper referred to as 'Binning' method), not means (in the paper referred to as 'Stacking method) because we use **median** when we plot data from our simulations (see, e.g., https://github.com/SWIFTSIM/pipeline-configs/blob/master/colibre/auto_plotter/gas_fraction_plots.yml#L214)

**BEFORE THE CHANGE**

![h2_frac_func_stellar_mass](https://user-images.githubusercontent.com/20153933/142508350-a297d331-d283-4a7a-9a6b-baa1d6f448b4.png)

**AFTER THE CHANGE**
![h2_frac_func_stellar_mass_new](https://user-images.githubusercontent.com/20153933/142508340-0c6ba4e9-6d71-4c14-9bc5-a38e9b2a8550.png)
