### PR TITLE
Add the FLAMINGO calibration data with biases

### DIFF
--- a/data/GalaxyStellarMassFunction/conversion/convertDriver2021FLAMINGOBias.py
+++ b/data/GalaxyStellarMassFunction/conversion/convertDriver2021FLAMINGOBias.py
@@ -98,7 +98,7 @@ log10_Phi_delta = np.array(
 # Add correction to z=0 and SDSS
 log10_Phi += 0.0769
 
-#Add corrections for the FLAMINGO Biases
+# Add corrections for the FLAMINGO Biases
 log10_Mstar += 0.03189831
 log10_Phi += np.log10(0.99693299)
 

--- a/data/GalaxyStellarMassFunction/conversion/convertDriver2021FLAMINGOBias.py
+++ b/data/GalaxyStellarMassFunction/conversion/convertDriver2021FLAMINGOBias.py
@@ -1,0 +1,151 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmologies
+h_obs = 0.7
+h_sim = cosmology.h
+
+output_filename = "Driver2021FLAMINGOBias.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+processed = ObservationalData()
+
+# Table 5
+log10_Mstar = np.array(
+    [
+        6.875,
+        7.125,
+        7.375,
+        7.625,
+        7.875,
+        8.125,
+        8.375,
+        8.625,
+        8.875,
+        9.125,
+        9.375,
+        9.625,
+        9.875,
+        10.125,
+        10.375,
+        10.625,
+        10.875,
+        11.125,
+        11.375,
+        11.625,
+    ]
+)
+log10_Phi = np.array(
+    [
+        -0.691,
+        -1.084,
+        -1.011,
+        -1.349,
+        -1.287,
+        -1.544,
+        -1.669,
+        -1.688,
+        -1.795,
+        -1.886,
+        -2.055,
+        -2.142,
+        -2.219,
+        -2.274,
+        -2.292,
+        -2.361,
+        -2.561,
+        -2.922,
+        -3.414,
+        -4.704,
+    ]
+)
+log10_Phi_delta = np.array(
+    [
+        0.176,
+        0.125,
+        0.071,
+        0.092,
+        0.079,
+        0.071,
+        0.045,
+        0.032,
+        0.024,
+        0.020,
+        0.014,
+        0.010,
+        0.009,
+        0.009,
+        0.009,
+        0.010,
+        0.013,
+        0.019,
+        0.032,
+        0.138,
+    ]
+)
+
+# Add correction to z=0 and SDSS
+log10_Phi += 0.0769
+
+#Add corrections for the FLAMINGO Biases
+log10_Mstar += 0.03189831
+log10_Phi += np.log10(0.99693299)
+
+log10_Phi_plus = log10_Phi + log10_Phi_delta
+log10_Phi_minus = log10_Phi - log10_Phi_delta
+
+# Convert to SWIFT-friendly units and correct for cosmology
+Mstar = (10.0 ** log10_Mstar) * unyt.Solar_Mass * (h_sim / h_obs) ** -2
+Phi = (10.0 ** log10_Phi) * unyt.Mpc ** (-3) * (h_sim / h_obs) ** 3
+Phi_plus = ((10.0 ** (log10_Phi_plus)) * unyt.Mpc ** (-3)) * (h_sim / h_obs) ** 3
+Phi_minus = ((10.0 ** (log10_Phi_minus)) * unyt.Mpc ** (-3)) * (h_sim / h_obs) ** 3
+
+Phi_plus = Phi_plus - Phi
+Phi_minus = Phi - Phi_minus
+
+# Meta-data
+comment = (
+    "Data obtained assuming a Chabrier IMF and h = 0.7. "
+    f"h-corrected for SWIFT using cosmology: {cosmology.name}. "
+    "Ignoring the mass bins for which GAMA is systematically incomplete."
+)
+citation = "Driver et al. (2021) (GAMA-DR4)"
+bibcode = "private communication"
+name = "GSMF from GAMA-DR4 (FLAMINGO Biases)"
+redshift = 0.0
+plot_as = "points"
+
+# Write everything
+processed.associate_x(
+    Mstar, scatter=None, comoving=True, description="Galaxy Stellar Mass"
+)
+processed.associate_y(
+    Phi,
+    scatter=unyt.unyt_array([Phi_minus, Phi_plus]),
+    comoving=True,
+    description="Phi (GSMF)",
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/HaloMassGasFractions/conversion/convertHSC-XXL.py
+++ b/data/HaloMassGasFractions/conversion/convertHSC-XXL.py
@@ -22,38 +22,39 @@ output_directory = "../"
 if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
-#Create a function for the fit from the paper
-def def_fgas_Aki(M500,z):
-    #Cosmology correct M500 to cited cosmology
-    M500_cc = M500 * (h_sim/70)**(1.0)
-    #Convert to scale free
+# Create a function for the fit from the paper
+def def_fgas_Aki(M500, z):
+    # Cosmology correct M500 to cited cosmology
+    M500_cc = M500 * (h_sim / 70) ** (1.0)
+    # Convert to scale free
     M500_cc_e = M500_cc * FLATCDM.efunc(z)
-    #Calculate ration with the pivot
-    Z = np.log(M500_cc_e/1e14)
-    #Calculate the term in the exponent
-    exp_term = 1.95 + 1.29*Z
-    #Calculate Mgas*E(z)
-    Mgas_e = np.exp(exp_term)*1e12
-    #Convert it to Mgas
+    # Calculate ration with the pivot
+    Z = np.log(M500_cc_e / 1e14)
+    # Calculate the term in the exponent
+    exp_term = 1.95 + 1.29 * Z
+    # Calculate Mgas*E(z)
+    Mgas_e = np.exp(exp_term) * 1e12
+    # Convert it to Mgas
     Mgas = Mgas_e / FLATCDM.efunc(z)
-    #Calculate fgas and cosmology correct it
-    fgas = Mgas * (68.1/70)**(-1.5) / M500_cc
-    #Error in the exponent
-    err_on_exp = np.sqrt(0.08**2 + (0.16)**2*Z**2)
-    #Convert to linear error
-    lin_err = np.abs(err_on_exp*np.exp(1.95 + 1.29*Z)*1e12)
-    #Apply cosmology correction terms
-    fgas_err = lin_err * (68.1/70)**(-1.5)/(M500_cc * FLATCDM.efunc(z))
+    # Calculate fgas and cosmology correct it
+    fgas = Mgas * (68.1 / 70) ** (-1.5) / M500_cc
+    # Error in the exponent
+    err_on_exp = np.sqrt(0.08 ** 2 + (0.16) ** 2 * Z ** 2)
+    # Convert to linear error
+    lin_err = np.abs(err_on_exp * np.exp(1.95 + 1.29 * Z) * 1e12)
+    # Apply cosmology correction terms
+    fgas_err = lin_err * (68.1 / 70) ** (-1.5) / (M500_cc * FLATCDM.efunc(z))
     return fgas, fgas_err
 
-# Read the data
-M_500  = np.array([10**(13.5),10**(14.5)])
-fb_500, error_fb_500_p = def_fgas_Aki(M_500,0.3)
 
-#Convert to proper units
-M_500 = unyt.unyt_array(M_500,units="Msun")
-fb_500 = unyt.unyt_array(fb_500,units="dimensionless")
-error_fb_500_p = unyt.unyt_array(error_fb_500_p,units="dimensionless")
+# Read the data
+M_500 = np.array([10 ** (13.5), 10 ** (14.5)])
+fb_500, error_fb_500_p = def_fgas_Aki(M_500, 0.3)
+
+# Convert to proper units
+M_500 = unyt.unyt_array(M_500, units="Msun")
+fb_500 = unyt.unyt_array(fb_500, units="dimensionless")
+error_fb_500_p = unyt.unyt_array(error_fb_500_p, units="dimensionless")
 error_fb_500_m = error_fb_500_p
 
 # Normalise by the cosmic mean
@@ -79,7 +80,7 @@ h = h_sim
 # Write everything
 processed = ObservationalData()
 processed.associate_x(
-    M_500, scatter=None ,comoving=True, description="Halo mass (M_500)"
+    M_500, scatter=None, comoving=True, description="Halo mass (M_500)"
 )
 processed.associate_y(
     fb_500, scatter=y_scatter, comoving=True, description="Gas fraction (<R_500)"

--- a/data/HaloMassGasFractions/conversion/convertHSC-XXL.py
+++ b/data/HaloMassGasFractions/conversion/convertHSC-XXL.py
@@ -1,0 +1,99 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+from astropy.cosmology import FlatLambdaCDM
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmology
+h_sim = cosmology.h
+Omega_b = cosmology.Ob0
+Omega_m = cosmology.Om0
+FLATCDM = FlatLambdaCDM(H0=70, Om0=0.30)
+
+output_filename = "HSC-XXL.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+#Create a function for the fit from the paper
+def def_fgas_Aki(M500,z):
+    #Cosmology correct M500 to cited cosmology
+    M500_cc = M500 * (h_sim/70)**(1.0)
+    #Convert to scale free
+    M500_cc_e = M500_cc * FLATCDM.efunc(z)
+    #Calculate ration with the pivot
+    Z = np.log(M500_cc_e/1e14)
+    #Calculate the term in the exponent
+    exp_term = 1.95 + 1.29*Z
+    #Calculate Mgas*E(z)
+    Mgas_e = np.exp(exp_term)*1e12
+    #Convert it to Mgas
+    Mgas = Mgas_e / FLATCDM.efunc(z)
+    #Calculate fgas and cosmology correct it
+    fgas = Mgas * (68.1/70)**(-1.5) / M500_cc
+    #Error in the exponent
+    err_on_exp = np.sqrt(0.08**2 + (0.16)**2*Z**2)
+    #Convert to linear error
+    lin_err = np.abs(err_on_exp*np.exp(1.95 + 1.29*Z)*1e12)
+    #Apply cosmology correction terms
+    fgas_err = lin_err * (68.1/70)**(-1.5)/(M500_cc * FLATCDM.efunc(z))
+    return fgas, fgas_err
+
+# Read the data
+M_500  = np.array([10**(13.5),10**(14.5)])
+fb_500, error_fb_500_p = def_fgas_Aki(M_500,0.3)
+
+#Convert to proper units
+M_500 = unyt.unyt_array(M_500,units="Msun")
+fb_500 = unyt.unyt_array(fb_500,units="dimensionless")
+error_fb_500_p = unyt.unyt_array(error_fb_500_p,units="dimensionless")
+error_fb_500_m = error_fb_500_p
+
+# Normalise by the cosmic mean
+fb_500 = fb_500 / (Omega_b / Omega_m)
+error_fb_500_p = error_fb_500_p / (Omega_b / Omega_m)
+error_fb_500_m = error_fb_500_m / (Omega_b / Omega_m)
+
+# Define the scatter as offset from the mean value
+y_scatter = unyt.unyt_array((error_fb_500_m, error_fb_500_p))
+
+# Meta-data
+comment = (
+    "Gas fraction data from the fit to weak-lensing mass HSC-XXL clusters. "
+    "Data was corrected for the simulation's cosmology."
+)
+citation = "Akino et al. (2021)"
+bibcode = " 2021arXiv211110080A"
+name = "HSC-XXL Gas Fractions"
+plot_as = "points"
+redshift = 0.3
+h = h_sim
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_500, scatter=None ,comoving=True, description="Halo mass (M_500)"
+)
+processed.associate_y(
+    fb_500, scatter=y_scatter, comoving=True, description="Gas fraction (<R_500)"
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/HaloMassGasFractions/conversion/convertHSE_FLAMINGO.py
+++ b/data/HaloMassGasFractions/conversion/convertHSE_FLAMINGO.py
@@ -1,0 +1,83 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+from astropy.cosmology import FlatLambdaCDM
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Cosmology
+h_sim = cosmology.h
+Omega_b = cosmology.Ob0
+Omega_m = cosmology.Om0
+FLATCDM = FlatLambdaCDM(H0=70, Om0=0.30)
+
+output_filename = "HSE-FLAMINGO.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+#The Data
+log10_M_500 = [13.6, 13.88571429, 14.05714286, 14.22857143, 14.4, 14.57142857, 14.74285714, 14.91428571]
+fb_500 = [0.07378083, 0.08326182, 0.09391293, 0.10494623, 0.11478259, 0.12976777, 0.12958898, 0.13943764]
+error_fb_500_p = [0.00371715, 0.00200495, 0.00314589, 0.00490072, 0.00817478, 0.00258178, 0.0021621,  0.00347187]
+
+#Apply Hydrostatic bias
+log10_M_500 -=  np.log10(0.74530875)
+
+# Read the data
+M_500  = 10**log10_M_500
+
+#Convert to proper units
+M_500 = unyt.unyt_array(M_500,units="Msun")
+fb_500 = unyt.unyt_array(fb_500,units="dimensionless")
+error_fb_500_p = unyt.unyt_array(error_fb_500_p,units="dimensionless")
+error_fb_500_m = error_fb_500_p
+
+# Normalise by the cosmic mean
+fb_500 = fb_500 / (Omega_b / Omega_m)
+error_fb_500_p = error_fb_500_p / (Omega_b / Omega_m)
+error_fb_500_m = error_fb_500_m / (Omega_b / Omega_m)
+
+# Define the scatter as offset from the mean value
+y_scatter = unyt.unyt_array((error_fb_500_m, error_fb_500_p))
+
+# Meta-data
+comment = (
+    "Gas fraction data by taking the median for a large set of HSE data. "
+    "This is the HSE calibration data for FLAMINGO. Includes fiducial bias. "
+    "Data was corrected for the simulation's cosmology."
+)
+citation = "FLAMINGO HSE Data"
+bibcode = " Personal collection"
+name = "HSE Gas Fractions"
+plot_as = "points"
+redshift = 0.1
+h = h_sim
+
+# Write everything
+processed = ObservationalData()
+processed.associate_x(
+    M_500, scatter=None, comoving=True, description="Halo mass (M_500)"
+)
+processed.associate_y(
+    fb_500, scatter=y_scatter, comoving=True, description="Gas fraction (<R_500)"
+)
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/HaloMassGasFractions/conversion/convertHSE_FLAMINGO.py
+++ b/data/HaloMassGasFractions/conversion/convertHSE_FLAMINGO.py
@@ -22,21 +22,48 @@ output_directory = "../"
 if not os.path.exists(output_directory):
     os.mkdir(output_directory)
 
-#The Data
-log10_M_500 = [13.6, 13.88571429, 14.05714286, 14.22857143, 14.4, 14.57142857, 14.74285714, 14.91428571]
-fb_500 = [0.07378083, 0.08326182, 0.09391293, 0.10494623, 0.11478259, 0.12976777, 0.12958898, 0.13943764]
-error_fb_500_p = [0.00371715, 0.00200495, 0.00314589, 0.00490072, 0.00817478, 0.00258178, 0.0021621,  0.00347187]
+# The Data
+log10_M_500 = [
+    13.6,
+    13.88571429,
+    14.05714286,
+    14.22857143,
+    14.4,
+    14.57142857,
+    14.74285714,
+    14.91428571,
+]
+fb_500 = [
+    0.07378083,
+    0.08326182,
+    0.09391293,
+    0.10494623,
+    0.11478259,
+    0.12976777,
+    0.12958898,
+    0.13943764,
+]
+error_fb_500_p = [
+    0.00371715,
+    0.00200495,
+    0.00314589,
+    0.00490072,
+    0.00817478,
+    0.00258178,
+    0.0021621,
+    0.00347187,
+]
 
-#Apply Hydrostatic bias
-log10_M_500 -=  np.log10(0.74530875)
+# Apply Hydrostatic bias
+log10_M_500 -= np.log10(0.74530875)
 
 # Read the data
-M_500  = 10**log10_M_500
+M_500 = 10 ** log10_M_500
 
-#Convert to proper units
-M_500 = unyt.unyt_array(M_500,units="Msun")
-fb_500 = unyt.unyt_array(fb_500,units="dimensionless")
-error_fb_500_p = unyt.unyt_array(error_fb_500_p,units="dimensionless")
+# Convert to proper units
+M_500 = unyt.unyt_array(M_500, units="Msun")
+fb_500 = unyt.unyt_array(fb_500, units="dimensionless")
+error_fb_500_p = unyt.unyt_array(error_fb_500_p, units="dimensionless")
 error_fb_500_m = error_fb_500_p
 
 # Normalise by the cosmic mean


### PR DESCRIPTION
Data needed for the two new FLAMINGO calibration plots in the pipeline. Has the three main datasets used for FLAMINGO including the fiducial corrections for the biases.