### PR TITLE
Radio and IR SFRD data

### DIFF
--- a/data/StarFormationRateHistory/conversion/convertEnia2022.py
+++ b/data/StarFormationRateHistory/conversion/convertEnia2022.py
@@ -1,0 +1,91 @@
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
+
+import unyt
+import numpy as np
+import os
+import sys
+
+
+def cosmic_star_formation_history_enia():
+
+    # Meta-data
+    name = f"Star formation rate density from Enia et al. (2022)"
+    comment = (
+        "Uses the Chabrier initial mass function. "
+        "Cosmology: Planck 2016: H0=67.8, OmegaM=0.308."
+    )
+
+    citation = "Enia et al. (2022)"
+    bibcode = "2022arXiv220200019E"
+    plot_as = "points"
+    output_filename = "Enia2022.hdf5"
+    output_directory = "../"
+
+    # Create observational data instance
+    processed = ObservationalData()
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_cosmology(cosmology)
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
+    # Load raw Enia2022 data
+    data = np.loadtxt(f"../raw/sfr_enia2022.dat")
+
+    # Fetch the fields we need
+    z_minus, z_plus = data[:, 0], data[:, 1]
+    SFR, SFR_stderr = data[:, 2], data[:, 3]
+
+    # Enia (2022) fig. 10 uses specific values for z in each bin, but does not
+    # explicitly list those in their table 4. We simply use the middle of each
+    # bin.
+    z_bin = unyt.unyt_array(0.5 * (z_minus + z_plus), units="dimensionless")
+    z_scatter = unyt.unyt_array(
+        (z_bin - z_minus, z_plus - z_bin), units="dimensionless"
+    )
+    # convert from log10(SFRD) to SFRD and carry the uncertainties
+    SFR_minus = 10.0 ** (SFR - SFR_stderr)
+    SFR_plus = 10.0 ** (SFR + SFR_stderr)
+    SFR = 10.0 ** SFR
+    SFR_scatter = unyt.unyt_array(
+        (SFR - SFR_minus, SFR_plus - SFR), units="Msun/yr/Mpc**3"
+    )
+    SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
+
+    processed.associate_x(
+        z_bin,
+        scatter=z_scatter,
+        comoving=False,
+        description="Cosmic redshift",
+    )
+    processed.associate_y(
+        SFR,
+        scatter=SFR_scatter,
+        comoving=False,
+        description="Cosmic average star formation rate density",
+    )
+
+    z_minus = z_minus.min()
+    z_plus = z_plus.max()
+    processed.associate_redshift(0.5 * (z_minus + z_plus), z_minus, z_plus)
+    processed.associate_plot_as(plot_as)
+
+    output_path = f"{output_directory}/{output_filename}"
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    processed.write(filename=output_path)
+
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Generate, format and save the Enia2022 data
+cosmic_star_formation_history_enia()

--- a/data/StarFormationRateHistory/conversion/convertEnia2022.py
+++ b/data/StarFormationRateHistory/conversion/convertEnia2022.py
@@ -44,10 +44,14 @@ def cosmic_star_formation_history_enia():
     # Enia (2022) fig. 10 uses specific values for z in each bin, but does not
     # explicitly list those in their table 4. We simply use the middle of each
     # bin.
-    z_bin = unyt.unyt_array(0.5 * (z_minus + z_plus), units="dimensionless")
-    z_scatter = unyt.unyt_array(
-        (z_bin - z_minus, z_plus - z_bin), units="dimensionless"
-    )
+    z = 0.5 * (z_minus + z_plus)
+
+    a = 1.0 / (1.0 + z)
+    a_minus = 1.0 / (1.0 + z_plus)
+    a_plus = 1.0 / (1.0 + z_minus)
+
+    a_bin = unyt.unyt_array(a, units="dimensionless")
+    a_scatter = unyt.unyt_array((a - a_minus, a_plus - a), units="dimensionless")
     # convert from log10(SFRD) to SFRD and carry the uncertainties
     SFR_minus = 10.0 ** (SFR - SFR_stderr)
     SFR_plus = 10.0 ** (SFR + SFR_stderr)
@@ -58,10 +62,10 @@ def cosmic_star_formation_history_enia():
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
     processed.associate_x(
-        z_bin,
-        scatter=z_scatter,
+        a_bin,
+        scatter=a_scatter,
         comoving=False,
-        description="Cosmic redshift",
+        description="Cosmic scale factor",
     )
     processed.associate_y(
         SFR,

--- a/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
+++ b/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
@@ -34,7 +34,7 @@ def cosmic_star_formation_history_gruppioni():
     if not os.path.exists(output_directory):
         os.mkdir(output_directory)
 
-    # Load raw Enia2022 data
+    # Load raw Gruppioni2020 data
     data = np.loadtxt(f"../raw/sfr_gruppioni2020.dat")
 
     # Fetch the fields we need
@@ -84,5 +84,5 @@ def cosmic_star_formation_history_gruppioni():
 with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
-# Generate, format and save the Enia2022 data
+# Generate, format and save the Gruppioni2020 data
 cosmic_star_formation_history_gruppioni()

--- a/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
+++ b/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
@@ -1,0 +1,84 @@
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
+
+import unyt
+import numpy as np
+import os
+import sys
+
+
+def cosmic_star_formation_history_gruppioni():
+
+    # Meta-data
+    name = f"Star formation rate density from Gruppioni et al. (2020)"
+    comment = (
+        "Uses the Chabrier initial mass function. "
+        "Cosmology: H0=70, OmegaM=0.3, OmegaL=0.7"
+    )
+
+    citation = "Gruppioni et al. (2020)"
+    bibcode = "2020A&A...643A...8G"
+    plot_as = "points"
+    output_filename = "Gruppioni2020.hdf5"
+    output_directory = "../"
+
+    # Create observational data instance
+    processed = ObservationalData()
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_cosmology(cosmology)
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
+    # Load raw Enia2022 data
+    data = np.loadtxt(f"../raw/sfr_gruppioni2020.dat")
+
+    # Fetch the fields we need
+    z_minus, z_plus = data[:, 0], data[:, 1]
+    SFR, SFR_min, SFR_max = data[:, 2], data[:, 3], data[:, 4]
+
+    z_bin = unyt.unyt_array(0.5 * (z_minus + z_plus), units="dimensionless")
+    z_scatter = unyt.unyt_array(
+        (z_bin - z_minus, z_plus - z_bin), units="dimensionless"
+    )
+    SFR_scatter = unyt.unyt_array(
+        (SFR - SFR_min, SFR_max - SFR), units="Msun/yr/Mpc**3"
+    )
+    SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
+
+    processed.associate_x(
+        z_bin,
+        scatter=z_scatter,
+        comoving=False,
+        description="Cosmic redshift",
+    )
+    processed.associate_y(
+        SFR,
+        scatter=SFR_scatter,
+        comoving=False,
+        description="Cosmic average star formation rate density",
+    )
+
+    z_minus = z_minus.min()
+    z_plus = z_plus.max()
+    processed.associate_redshift(0.5 * (z_minus + z_plus), z_minus, z_plus)
+    processed.associate_plot_as(plot_as)
+
+    output_path = f"{output_directory}/{output_filename}"
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    processed.write(filename=output_path)
+
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Generate, format and save the Enia2022 data
+cosmic_star_formation_history_gruppioni()

--- a/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
+++ b/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
@@ -41,20 +41,24 @@ def cosmic_star_formation_history_gruppioni():
     z_minus, z_plus = data[:, 0], data[:, 1]
     SFR, SFR_min, SFR_max = data[:, 2], data[:, 3], data[:, 4]
 
-    z_bin = unyt.unyt_array(0.5 * (z_minus + z_plus), units="dimensionless")
-    z_scatter = unyt.unyt_array(
-        (z_bin - z_minus, z_plus - z_bin), units="dimensionless"
-    )
+    z = 0.5 * (z_minus + z_plus)
+
+    a = 1.0 / (1.0 + z)
+    a_minus = 1.0 / (1.0 + z_plus)
+    a_plus = 1.0 / (1.0 + z_minus)
+
+    a_bin = unyt.unyt_array(a, units="dimensionless")
+    a_scatter = unyt.unyt_array((a - a_minus, a_plus - a), units="dimensionless")
     SFR_scatter = unyt.unyt_array(
         (SFR - SFR_min, SFR_max - SFR), units="Msun/yr/Mpc**3"
     )
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
     processed.associate_x(
-        z_bin,
-        scatter=z_scatter,
+        a_bin,
+        scatter=a_scatter,
         comoving=False,
-        description="Cosmic redshift",
+        description="Cosmic scale factor",
     )
     processed.associate_y(
         SFR,

--- a/data/StarFormationRateHistory/conversion/convertNovak2017.py
+++ b/data/StarFormationRateHistory/conversion/convertNovak2017.py
@@ -1,0 +1,87 @@
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
+
+import unyt
+import numpy as np
+import os
+import sys
+
+
+def cosmic_star_formation_history_novak():
+
+    # Meta-data
+    name = f"Star formation rate density from Novak et al. (2017)"
+    comment = (
+        "based on JVLA COSMOS radio observations at 3 GHz "
+        "cosmology is H0=70, OmegaM=0.3, OmegaL=0.7 "
+        "Uses a Chabrier IMF"
+    )
+
+    citation = "Novak et al. (2017)"
+    bibcode = "2017A&A...602A...5N"
+    plot_as = "points"
+    output_filename = "Novak2017.hdf5"
+    output_directory = "../"
+
+    # Create observational data instance
+    processed = ObservationalData()
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_cosmology(cosmology)
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
+    # Load raw Enia2022 data
+    data = np.loadtxt(f"../raw/sfr_novak2017.dat")
+
+    # Fetch the fields we need
+    z, z_minus, z_plus = data[:, 0], data[:, 1], data[:, 2]
+    SFR, SFR_minus, SFR_plus = data[:, 3], data[:, 4], data[:, 5]
+
+    z_bin = unyt.unyt_array(z, units="dimensionless")
+    z_scatter = unyt.unyt_array((-z_minus, z_plus), units="dimensionless")
+    # convert from log10(SFRD) to SFRD and carry the uncertainties
+    SFR_minus = 10.0 ** (SFR + SFR_minus)
+    SFR_plus = 10.0 ** (SFR + SFR_plus)
+    SFR = 10.0 ** SFR
+    SFR_scatter = unyt.unyt_array(
+        (SFR - SFR_minus, SFR_plus - SFR), units="Msun/yr/Mpc**3"
+    )
+    SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
+
+    processed.associate_x(
+        z_bin,
+        scatter=z_scatter,
+        comoving=False,
+        description="Cosmic redshift",
+    )
+    processed.associate_y(
+        SFR,
+        scatter=SFR_scatter,
+        comoving=False,
+        description="Cosmic average star formation rate density",
+    )
+
+    z_minus = (z + z_minus).min()
+    z_plus = (z + z_plus).max()
+    processed.associate_redshift(0.5 * (z_minus + z_plus), z_minus, z_plus)
+    processed.associate_plot_as(plot_as)
+
+    output_path = f"{output_directory}/{output_filename}"
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    processed.write(filename=output_path)
+
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Generate, format and save the Enia2022 data
+cosmic_star_formation_history_novak()

--- a/data/StarFormationRateHistory/conversion/convertNovak2017.py
+++ b/data/StarFormationRateHistory/conversion/convertNovak2017.py
@@ -48,7 +48,6 @@ def cosmic_star_formation_history_novak():
     a_plus = 1.0 / (1.0 + z + delta_z_minus)
     delta_a_minus = a - a_minus
     delta_a_plus = a_plus - a
-    print(delta_a_minus, delta_a_plus)
 
     a_bin = unyt.unyt_array(a, units="dimensionless")
     a_scatter = unyt.unyt_array((delta_a_minus, delta_a_plus), units="dimensionless")

--- a/data/StarFormationRateHistory/conversion/convertNovak2017.py
+++ b/data/StarFormationRateHistory/conversion/convertNovak2017.py
@@ -35,7 +35,7 @@ def cosmic_star_formation_history_novak():
     if not os.path.exists(output_directory):
         os.mkdir(output_directory)
 
-    # Load raw Enia2022 data
+    # Load raw Novak2017 data
     data = np.loadtxt(f"../raw/sfr_novak2017.dat")
 
     # Fetch the fields we need
@@ -90,5 +90,5 @@ def cosmic_star_formation_history_novak():
 with open(sys.argv[1], "r") as handle:
     exec(handle.read())
 
-# Generate, format and save the Enia2022 data
+# Generate, format and save the Novak2017 data
 cosmic_star_formation_history_novak()

--- a/data/StarFormationRateHistory/raw/sfr_enia2022.dat
+++ b/data/StarFormationRateHistory/raw/sfr_enia2022.dat
@@ -1,0 +1,13 @@
+# cosmic star formation rate density from Enia et al. (2022)
+#   based on JVLA radio observations from a subsample of the GOODS-N survey
+#   cosmology is H0=67.8, OmegaM=0.308 (Planck 2016)
+#   Uses a Chabrier IMF
+#   The last bin is labeled z>3 in the paper, but spans z=3-4 in their figure 10.
+#   We use the z>3 bin based on galaxies with a measured photo-z
+#   zmin   zmax   log10 sfrd (Msol/yr/Mpc^3)   sfrderror
+0.1	0.4	-1.78	0.24
+0.4	0.7	-1.38	0.14
+0.7	1.0	-1.16	0.16
+1.0	2.0	-0.96	0.17
+2.0	3.0	-0.99	0.22
+3.0	4.0	-1.09	0.25

--- a/data/StarFormationRateHistory/raw/sfr_gruppioni2020.dat
+++ b/data/StarFormationRateHistory/raw/sfr_gruppioni2020.dat
@@ -1,0 +1,10 @@
+# cosmic star formation rate density from Gruppioni et al. (2020)
+#   based on [CII] observations from the ALPINE-ALMA survey
+#   cosmology is H0=70, OmegaM=0.3, OmegaL=0.7
+#   Uses a Chabrier IMF
+#   zmin   zmax   sfrd (Msol/yr/Mpc^3)   sfrd_min   sfrd_max
+0.5	1.5	7.93e-2	5.19e-2	1.42e-1
+1.5	2.5	9.96e-2	5.64e-2	1.94e-1
+2.5	3.5	1.23e-1	8.57e-2	1.88e-1
+3.5	4.5	6.06e-2	3.82e-2	1.00e-1
+4.5	6.0	5.57e-2	2.49e-2	1.51e-1

--- a/data/StarFormationRateHistory/raw/sfr_novak2017.dat
+++ b/data/StarFormationRateHistory/raw/sfr_novak2017.dat
@@ -1,0 +1,17 @@
+# cosmic star formation rate density from Novak et al. (2017)
+#   based on JVLA COSMOS radio observations at 3 GHz
+#   cosmology is H0=70, OmegaM=0.3, OmegaL=0.7
+#   Uses a Chabrier IMF
+#   The rates here are the Total rates based on pure luminosity evolution.
+#   z   zerror_low   zerror_high   log10 sfrd (Msol/yr/Mpc^3)   sfrderror_low    sfrderror_high
+0.312	-0.21	0.088	-1.77	-0.052	0.047
+0.501	-0.10	0.099	-1.69	-0.050	0.045
+0.695	-0.095	0.11	-1.47	-0.048	0.044
+0.903	-0.10	0.097	-1.31	-0.048	0.044
+1.16	-0.16	0.14	-1.31	-0.049	0.043
+1.44	-0.14	0.16	-1.24	-0.051	0.045
+1.81	-0.21	0.19	-1.16	-0.053	0.047
+2.18	-0.18	0.32	-1.10	-0.056	0.048
+2.81	-0.31	0.49	-1.08	-0.060	0.052
+3.71	-0.41	0.89	-1.23	-0.079	0.062
+4.83	-0.23	0.87	-1.25	-0.13	0.085


### PR DESCRIPTION
This adds SFRD data from Novak et al. (2017), Gruppioni et al. (2020) and Enia et al. (2022). The figure shows the new data (and Madau & Dickinson 2014 for reference):

![SFRD](https://user-images.githubusercontent.com/7336967/152796548-2269c77b-71aa-4922-8cdb-956e91ccb48c.png)

This can also be compared with the left panel in Fig. 10 of Enia et al. (2022).