### PR TITLE
Fixed black formatting

### DIFF
--- a/data/GalaxyStellarMassFunction/conversion/convertDSouza2015.py
+++ b/data/GalaxyStellarMassFunction/conversion/convertDSouza2015.py
@@ -35,10 +35,11 @@ M_max = (10 ** 12.0) * unyt.Solar_Mass * h_sim ** (-2)  # Msun
 M = np.logspace(np.log10(M_min), np.log10(M_max), 50) * unyt.Solar_Mass  # Msun
 
 # Create the y-data (double Schechter)
-Phi_Md_M = (
-    (phi_star_1 / M_star_1) * np.exp(-M / M_star_1) * (M / M_star_1) ** alpha_1
-    + (phi_star_2 / M_star_2) * np.exp(-M / M_star_2) * (M / M_star_2) ** alpha_2
-)
+Phi_Md_M = (phi_star_1 / M_star_1) * np.exp(-M / M_star_1) * (
+    M / M_star_1
+) ** alpha_1 + (phi_star_2 / M_star_2) * np.exp(-M / M_star_2) * (
+    M / M_star_2
+) ** alpha_2
 Phi = Phi_Md_M * M * np.log(10)
 
 # Meta-data

--- a/data/GalaxyStellarMassFunction/conversion/convertDSouza2015.py
+++ b/data/GalaxyStellarMassFunction/conversion/convertDSouza2015.py
@@ -35,11 +35,10 @@ M_max = (10 ** 12.0) * unyt.Solar_Mass * h_sim ** (-2)  # Msun
 M = np.logspace(np.log10(M_min), np.log10(M_max), 50) * unyt.Solar_Mass  # Msun
 
 # Create the y-data (double Schechter)
-Phi_Md_M = (phi_star_1 / M_star_1) * np.exp(-M / M_star_1) * (
-    M / M_star_1
-) ** alpha_1 + (phi_star_2 / M_star_2) * np.exp(-M / M_star_2) * (
-    M / M_star_2
-) ** alpha_2
+Phi_Md_M = (
+    (phi_star_1 / M_star_1) * np.exp(-M / M_star_1) * (M / M_star_1) ** alpha_1
+    + (phi_star_2 / M_star_2) * np.exp(-M / M_star_2) * (M / M_star_2) ** alpha_2
+)
 Phi = Phi_Md_M * M * np.log(10)
 
 # Meta-data

--- a/data/StarFormationRateHistory/conversion/convertBehroozi2019.py
+++ b/data/StarFormationRateHistory/conversion/convertBehroozi2019.py
@@ -58,10 +58,7 @@ def cosmic_star_formation_history_observed():
     redshift, redshift_lower, redshift_upper = 5.0, 0.0, 10.0
 
     processed.associate_x(
-        scale_factor,
-        scatter=None,
-        comoving=False,
-        description="Cosmic scale factor",
+        scale_factor, scatter=None, comoving=False, description="Cosmic scale factor"
     )
     processed.associate_y(
         SFR * SFR_scatter.units,
@@ -126,10 +123,7 @@ def cosmic_star_formation_history_true():
     redshift, redshift_lower, redshift_upper = 5.0, 0.0, 10.0
 
     processed.associate_x(
-        scale_factor,
-        scatter=None,
-        comoving=False,
-        description="Cosmic scale factor",
+        scale_factor, scatter=None, comoving=False, description="Cosmic scale factor"
     )
     processed.associate_y(
         SFR * SFR_scatter.units,

--- a/data/StarFormationRateHistory/conversion/convertEnia2022.py
+++ b/data/StarFormationRateHistory/conversion/convertEnia2022.py
@@ -62,10 +62,7 @@ def cosmic_star_formation_history_enia():
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
     processed.associate_x(
-        a_bin,
-        scatter=a_scatter,
-        comoving=False,
-        description="Cosmic scale factor",
+        a_bin, scatter=a_scatter, comoving=False, description="Cosmic scale factor"
     )
     processed.associate_y(
         SFR,

--- a/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
+++ b/data/StarFormationRateHistory/conversion/convertGruppioni2020.py
@@ -55,10 +55,7 @@ def cosmic_star_formation_history_gruppioni():
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
     processed.associate_x(
-        a_bin,
-        scatter=a_scatter,
-        comoving=False,
-        description="Cosmic scale factor",
+        a_bin, scatter=a_scatter, comoving=False, description="Cosmic scale factor"
     )
     processed.associate_y(
         SFR,

--- a/data/StarFormationRateHistory/conversion/convertNovak2017.py
+++ b/data/StarFormationRateHistory/conversion/convertNovak2017.py
@@ -61,10 +61,7 @@ def cosmic_star_formation_history_novak():
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
     processed.associate_x(
-        a_bin,
-        scatter=a_scatter,
-        comoving=False,
-        description="Cosmic scale factor",
+        a_bin, scatter=a_scatter, comoving=False, description="Cosmic scale factor"
     )
     processed.associate_y(
         SFR,

--- a/format.sh
+++ b/format.sh
@@ -1,20 +1,39 @@
-#!bash
+#!/bin/bash
 # Formats all relevant source code files.
 # Accepts an extra input argument that is passed to black.
 # Useful for --check.
+
+# Check if we can run pip
+# This also serves as a check for python3
+python3 -m pip --version > /dev/null
+if [[ $? -ne 0 ]]
+then
+  echo "ERROR: cannot run 'python3 -m pip'"
+  exit 1
+fi
+
+# Check if the virtual environment with black exists
+if [ ! -d black_formatting_env ]
+then
+  echo "Formatting environment not found, installing it..."
+  python3 -m venv black_formatting_env
+  ./black_formatting_env/bin/python3 -m pip install click==8.0.4 black==21.12b0
+fi
+# Now we know exactly which black to use
+black="./black_formatting_env/bin/python3 -m black"
 
 extra_arg=${1}
 
 return_code=0
 
-black cosmology.py $extra_arg
+$black cosmology.py $extra_arg
 return_code=$(( $return_code > $? ? $return_code : $? ))
-black plot_individual_dataset.py $extra_arg
+$black plot_individual_dataset.py $extra_arg
 return_code=$(( $return_code > $? ? $return_code : $? ))
-black convert.py $extra_arg
+$black convert.py $extra_arg
 return_code=$(( $return_code > $? ? $return_code : $? ))
 
-black data/*/conversion/*.py $extra_arg
+$black data/*/conversion/*.py $extra_arg
 return_code=$(( $return_code > $? ? $return_code : $? ))
 
 exit $return_code


### PR DESCRIPTION
There were two issues with the formatting script:
 - it did not specify a `black` version, so that the formatting depends on the machine
 - the `black` version on the CI runners is broken because of a compatibility issue with `click`

I have fixed this in the same way as for the other repositories, by
- setting up a virtual environment for the formatting, so that we can control the `black` version
- also pinning the `click` version to a version that is compatible with `black`

While I chose the same `black` version as the CI runners, there were still some small formatting changes in some of the scripts.