### PR TITLE
Remove negative scatter from Behroozi19 data

### DIFF
--- a/data/GalaxyStellarMassFunction/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassFunction/conversion/convertBehroozi2019.py
@@ -69,6 +69,8 @@ def Phi_all_galaxies():
         Phi_scatter = unyt.unyt_array(
             (Phi_minus[mask], Phi_plus[mask]), units=unyt.Mpc ** (-3)
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        Phi_scatter[Phi_scatter < 0.0] = 0.0
 
         # Compute \Delta z
         redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]
@@ -158,6 +160,8 @@ def Phi_passive_galaxies():
         Phi_scatter = unyt.unyt_array(
             (Phi_minus[mask], Phi_plus[mask]), units=unyt.Mpc ** (-3)
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        Phi_scatter[Phi_scatter < 0.0] = 0.0
 
         # Compute \Delta z
         redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]

--- a/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassHaloMass/conversion/convertBehroozi2019.py
@@ -177,6 +177,8 @@ def StellarMass_vs_HaloMass():
 
         # Define scatter
         y_scatter = unyt.unyt_array((M_star - M_16, M_84 - M_star))
+        # Mask out negative scatter (a very small per cent of the data)
+        y_scatter[y_scatter < 0.0] = 0.0
 
         processed.associate_x(
             M_BN98 * unyt.Solar_Mass,
@@ -252,6 +254,8 @@ def StellarMassHaloMassRatios_vs_HaloMass():
         y_scatter = unyt.unyt_array(
             ((M_star - M_16) / M_BN98, (M_84 - M_star) / M_BN98)
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        y_scatter[y_scatter < 0.0] = 0.0
 
         processed.associate_x(
             M_BN98 * unyt.Solar_Mass,
@@ -328,6 +332,8 @@ def StellarMassHaloMassRatios_vs_StellarMass():
         y_scatter = unyt.unyt_array(
             ((M_star - M_16) / M_BN98, (M_84 - M_star) / M_BN98)
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        y_scatter[y_scatter < 0.0] = 0.0
 
         processed.associate_x(
             M_star * unyt.Solar_Mass,

--- a/data/GalaxyStellarMassPassiveFraction/conversion/convertBehroozi2019.py
+++ b/data/GalaxyStellarMassPassiveFraction/conversion/convertBehroozi2019.py
@@ -68,6 +68,8 @@ def passive_fractions():
         QF_scatter = unyt.unyt_array(
             (QF_minus[mask], QF_plus[mask]), units="dimensionless"
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        QF_scatter[QF_scatter < 0.0] = 0.0
 
         # Compute \Delta z
         redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]
@@ -160,6 +162,8 @@ def passive_fractions_centrals():
         QF_scatter = unyt.unyt_array(
             (QF_minus[mask], QF_plus[mask]), units="dimensionless"
         )
+        # Mask out negative scatter (a very small per cent of the data)
+        QF_scatter[QF_scatter < 0.0] = 0.0
 
         # Compute \Delta z
         redshift_lower, redshift_upper = [z - dz_lower, z + dz_upper]


### PR DESCRIPTION
A small fraction (no more than a few per cent) of data plots from the Behroozi19 data has a negative scatter, which means that the error bars are entirely below or above the best-fit value. This is not a bug (confirmed by Peter Behroozi).

The new versions of `matplotlib` library (version >= 3.6.0 I think) do not allow negative scatter in errorbar plots. This is why in this PR I replace all negative scatter values in the Behroozi19 scripts with zeros.