### PR TITLE
Use the Asplund09 value for Zsolal and update references to Fraser-McKelvie's data 

### DIFF
--- a/cosmology.py
+++ b/cosmology.py
@@ -1,6 +1,7 @@
 from astropy.cosmology import Planck15 as cosmology
 
-solar_metallicity = 0.0126
+# Asplund et al. (2009)
+solar_metallicity = 0.0134
 
 # IMF conversion factors from Furlong+ 2015
 kroupa_to_chabrier_mass = 0.912

--- a/data/GalaxyStellarMassGasMetallicity/conversion/convertFraser-McKelvie2021.py
+++ b/data/GalaxyStellarMassGasMetallicity/conversion/convertFraser-McKelvie2021.py
@@ -46,8 +46,8 @@ comment = (
     "The R-calibration of Pilyugin & Grebel (2016) was employed to determine oxygen abundances. "
     "The metallicity is expressed as 12 + log10(O/H). In these units the solar metallicity is 8.69."
 )
-citation = "Fraser-McKelvie et al. (2021)"
-bibcode = " 2021MNRAS.tmp.3132F"
+citation = "Fraser-McKelvie et al. (2022, SAMI)"
+bibcode = "2022MNRAS.510..320F"
 name = "Stellar mass - gas phase metallicity relation "
 plot_as = "points"
 redshift = 0.1

--- a/data/GalaxyStellarMassStellarMetallicity/conversion/convertFraser-McKelvie2021.py
+++ b/data/GalaxyStellarMassStellarMetallicity/conversion/convertFraser-McKelvie2021.py
@@ -61,8 +61,8 @@ comment = (
     "average ages and metallicities of the SAMI galaxies from "
     "the 1Re aperture spectra. "
 )
-citation = "Fraser-McKelvie et al. (2021)"
-bibcode = " 2021MNRAS.tmp.3132F"
+citation = "Fraser-McKelvie et al. (2022, SAMI)"
+bibcode = "2022MNRAS.510..320F"
 name = "Stellar mass - stellar metallicity relation "
 plot_as = "points"
 redshift = 0.1


### PR DESCRIPTION
- Use the Asplund09 value for solar metallicity in `cosmology.py` (this is the value that we should use everywhere in the code; I am not sure why in `cosmology.py` we currently have a different value).
- Update references to Fraser-McKelvie's data because the paper has been published (before we were referring to the submitted but not final version. Also indicate in the data's legend that the data comes from the SAMI survey). 