### PR TITLE
Fix conversion script for Bauer2013+, all galaxies

### DIFF
--- a/data/GalaxyStellarMassSpecificStarFormationRate/conversion/convertBauer2013_AllGalaxies.py
+++ b/data/GalaxyStellarMassSpecificStarFormationRate/conversion/convertBauer2013_AllGalaxies.py
@@ -35,7 +35,7 @@ h = cosmology.h
 
 log_M = raw.T[0]
 M = unyt.unyt_array(10 ** (log_M), units=unyt.Solar_Mass)
-sSFR = unyt.unyt_array(10 ** raw.T[5], units=1 / unyt.year)
+sSFR = unyt.unyt_array(10 ** raw.T[4], units=1 / unyt.year)
 
 processed.associate_x(
     M, scatter=None, comoving=False, description="Galaxy Stellar Mass"


### PR DESCRIPTION
The older version would select the lower limits on the detected SFRs. The new version correctly selects the data for all galaxies.

**Before**

![stellar_mass_specific_sfr_all_50_old](https://user-images.githubusercontent.com/20153933/229481974-812118ad-c4f8-45c5-8034-bcf470fa70c0.png)


**After**

![stellar_mass_specific_sfr_all_50](https://user-images.githubusercontent.com/20153933/229482053-2bff5132-9196-4883-b22f-22313b4c9db7.png)
