### PR TITLE
Add Khusanova data

### DIFF
--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -1,6 +1,5 @@
 from velociraptor.observations.objects import (
     ObservationalData,
-    MultiRedshiftObservationalData,
 )
 
 import unyt

--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -1,0 +1,78 @@
+from velociraptor.observations.objects import (
+    ObservationalData,
+    MultiRedshiftObservationalData,
+)
+
+import unyt
+import numpy as np
+import os
+import sys
+
+
+def cosmic_star_formation_history_khusanova():
+    # Meta-data
+    name = f"Star formation rate density from Enia et al. (2022)"
+    comment = (
+        "Uses the Chabrier initial mass function. " "Cosmology: H0=70.0, OmegaM=0.30."
+    )
+
+    citation = "Khusanova et al. (2021)"
+    bibcode = "2021A&A...649A.152K"
+    plot_as = "points"
+    output_filename = "Khusanova2021.hdf5"
+    output_directory = "../"
+
+    # Create observational data instance
+    processed = ObservationalData()
+    processed.associate_citation(citation, bibcode)
+    processed.associate_name(name)
+    processed.associate_comment(comment)
+    processed.associate_cosmology(cosmology)
+
+    if not os.path.exists(output_directory):
+        os.mkdir(output_directory)
+
+    # Load raw Khusanova2021 data
+    data = np.loadtxt(f"../raw/sfr_khusanova2021.dat")
+
+    # Fetch the fields we need
+    z = data[:, 0]
+    SFR, SFR_stderr_low, SFR_stderr_high = data[:, 1], data[:, 2], data[:, 3]
+
+    a = 1.0 / (1.0 + z)
+
+    a_bin = unyt.unyt_array(a, units="dimensionless")
+    # convert from log10(SFRD) to SFRD and carry the uncertainties
+    SFR_minus = 10.0 ** (SFR - SFR_stderr_low)
+    SFR_plus = 10.0 ** (SFR + SFR_stderr_high)
+    SFR = 10.0**SFR
+    SFR_scatter = unyt.unyt_array(
+        (SFR - SFR_minus, SFR_plus - SFR), units="Msun/yr/Mpc**3"
+    )
+    SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
+
+    processed.associate_x(a_bin, comoving=False, description="Cosmic scale factor")
+    processed.associate_y(
+        SFR,
+        scatter=SFR_scatter,
+        comoving=False,
+        description="Cosmic average star formation rate density",
+    )
+
+    processed.associate_redshift(z)
+    processed.associate_plot_as(plot_as)
+
+    output_path = f"{output_directory}/{output_filename}"
+
+    if os.path.exists(output_path):
+        os.remove(output_path)
+
+    processed.write(filename=output_path)
+
+
+# Exec the master cosmology file passed as first argument
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+# Generate, format and save the Enia2022 data
+cosmic_star_formation_history_khusanova()

--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -51,7 +51,9 @@ def cosmic_star_formation_history_khusanova():
     )
     SFR = unyt.unyt_array(SFR, units="Msun/yr/Mpc**3")
 
-    processed.associate_x(a_bin, comoving=False, description="Cosmic scale factor")
+    processed.associate_x(
+        a_bin, scatter=None, comoving=False, description="Cosmic scale factor"
+    )
     processed.associate_y(
         SFR,
         scatter=SFR_scatter,

--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -45,7 +45,7 @@ def cosmic_star_formation_history_khusanova():
     # convert from log10(SFRD) to SFRD and carry the uncertainties
     SFR_minus = 10.0 ** (SFR - SFR_stderr_low)
     SFR_plus = 10.0 ** (SFR + SFR_stderr_high)
-    SFR = 10.0**SFR
+    SFR = 10.0 ** SFR
     SFR_scatter = unyt.unyt_array(
         (SFR - SFR_minus, SFR_plus - SFR), units="Msun/yr/Mpc**3"
     )

--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -11,7 +11,7 @@ import sys
 
 def cosmic_star_formation_history_khusanova():
     # Meta-data
-    name = f"Star formation rate density from Enia et al. (2022)"
+    name = "Star formation rate density from Khusanova et al. (2021)"
     comment = (
         "Uses the Chabrier initial mass function. " "Cosmology: H0=70.0, OmegaM=0.30."
     )

--- a/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
+++ b/data/StarFormationRateHistory/conversion/convertKhusanova2021.py
@@ -59,7 +59,7 @@ def cosmic_star_formation_history_khusanova():
         description="Cosmic average star formation rate density",
     )
 
-    processed.associate_redshift(z)
+    processed.associate_redshift(np.mean(z))
     processed.associate_plot_as(plot_as)
 
     output_path = f"{output_directory}/{output_filename}"

--- a/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
+++ b/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
@@ -1,0 +1,7 @@
+# cosmic star formation rate density from Khusanova et al. (2021)
+#   based on Almao radio observations from the ALPINE survey
+#   cosmology is H0=70.0, OmegaM=0.30
+#   Uses a Chabrier IMF
+#   z   log10 sfrd (Msol/yr/Mpc^3)   sfrderror_low sfrderror_high
+4.5  -1.28  0.36  0.38
+5.5  -1.38  0.28  0.36

--- a/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
+++ b/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
@@ -1,5 +1,5 @@
 # cosmic star formation rate density from Khusanova et al. (2021)
-#   based on Almao radio observations from the ALPINE survey
+#   based on ALMA radio observations from the ALPINE survey
 #   cosmology is H0=70.0, OmegaM=0.30
 #   Uses a Chabrier IMF
 #   z   log10 sfrd (Msol/yr/Mpc^3)   sfrderror_low sfrderror_high

--- a/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
+++ b/data/StarFormationRateHistory/raw/sfr_khusanova2021.dat
@@ -4,4 +4,4 @@
 #   Uses a Chabrier IMF
 #   z   log10 sfrd (Msol/yr/Mpc^3)   sfrderror_low sfrderror_high
 4.5  -1.28  0.36  0.38
-5.5  -1.38  0.28  0.36
+5.5  -1.60  0.28  0.36


### PR DESCRIPTION
This adds the Khusanova 2021 data to the Star formation history data.

To make this work with the script this requires the addition of the data to
https://github.com/SWIFTSIM/pipeline-configs/blob/8a570af60dcec1992b7ef5239c40dd2ef7ec97e2/colibre/scripts/star_formation_history.py#L138
The correct label for this data is FIR (just like what Gruppioni should also be).
