### PR TITLE
Add swiftsimio to the requirements in order to fix the error in the KS-relation scripts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ velociraptor
 matplotlib
 numpy
 scipy
+swiftsimio


### PR DESCRIPTION
The error would manifest if one would try to install this repository from scratch (as is done in the automated tests), without having `swiftsimio` installed.

Here is an example of this error in the automated tests

![Screenshot from 2023-04-16 15-33-39](https://user-images.githubusercontent.com/20153933/232315242-dba86b55-4c79-46fb-bb12-87fc7052cef6.png)
