### PR TITLE
Update script converting HIMF data from Jones et al (2018)

### DIFF
--- a/data/GalaxyHIMassFunction/conversion/convertJones2018.py
+++ b/data/GalaxyHIMassFunction/conversion/convertJones2018.py
@@ -3,9 +3,7 @@ from velociraptor.observations.objects import ObservationalData
 import unyt
 import numpy as np
 import os
-import re
 import sys
-import itertools as it
 
 ORIGINAL_H = 0.7
 
@@ -32,9 +30,9 @@ comment = (
     f"data, h-corrected for SWIFT using Cosmology: {cosmology.name}."
 )
 
-citation = "Jones et al. (2018), z = 0"
+citation = "Jones et al. (2018, ALFALFA)"
 bibcode = "2018MNRAS.477....2J"
-name = "HIMF from ALFALFA at z=0"
+name = "HI mass function from ALFALFA at z=0"
 plot_as = "points"
 redshift = 0.0
 h = cosmology.h


### PR DESCRIPTION
The main purpose of this update is to add `ALFALFA' to the label of the data. This way it is clear which survey the data is coming from.

Other small changes in the script are just a clean-up and comment improvements.