### PR TITLE
Add HI mass function at z=0 from Ponomareva et al (2023)

### DIFF
--- a/data/GalaxyHIMassFunction/conversion/convertPonomareva2023.py
+++ b/data/GalaxyHIMassFunction/conversion/convertPonomareva2023.py
@@ -1,0 +1,69 @@
+from velociraptor.observations.objects import ObservationalData
+
+import unyt
+import numpy as np
+import os
+import sys
+
+ORIGINAL_H = 0.674
+
+# Exec the master cosmology file passed as first argument
+# These lines are _required_ and you are required to use
+# the cosmology specified (this is an astropy.cosmology
+# instance)
+with open(sys.argv[1], "r") as handle:
+    exec(handle.read())
+
+input_filename = "../raw/Ponomareva2023.txt"
+output_filename = "Ponomareva2023.hdf5"
+output_directory = "../"
+
+if not os.path.exists(output_directory):
+    os.mkdir(output_directory)
+
+data = np.genfromtxt(input_filename, comments="#")
+
+processed = ObservationalData()
+
+comment = (
+    "The HI mass function from the MeerKAT telescope's data based on 276 direct detections from "
+    "the MIGHTEE Survey Early Science data covering redshifts 0 < z < 0.084. "
+    "Uses the Planck Collaboration et al. (2020) cosmology: h = 0.674, Omegam = 0.315, "
+    "and OmegaL = 0.685. "
+    "The authors define a critical HI line flux above which the sample is expected to be 100 complete. This leaves "
+    "them with 203 sources from which the HI mass function is subsequently constructed."
+)
+
+citation = "Ponomareva et al. (2023, MIGHTEE)"
+bibcode = "2023MNRAS.tmp.1270P"
+name = "HI mass function from the MIGHTEE Survey at z=0"
+plot_as = "points"
+redshift = 0.0
+h = cosmology.h
+
+M = 10 ** data[:, 0] * (h / ORIGINAL_H) ** (-2) * unyt.Solar_Mass
+# no error in M_HI provided
+M_err = np.row_stack([M * 0.0] * 2) * M.units
+
+Phi = 10 ** data[:, 1] * (h / ORIGINAL_H) ** 3
+Phi_err_p = 10 ** (data[:, 1] + data[:, 2]) * (h / ORIGINAL_H) ** 3 - Phi
+Phi_err_m = Phi - 10 ** (data[:, 1] - data[:, 3]) * (h / ORIGINAL_H) ** 3
+Phi = unyt.unyt_array(Phi, units="1/Mpc**3")
+Phi_err = unyt.unyt_array([Phi_err_m, Phi_err_p], units="1/Mpc**3")
+
+
+processed.associate_x(M, scatter=M_err, comoving=True, description="Galaxy HI Mass")
+processed.associate_y(Phi, scatter=Phi_err, comoving=True, description="Phi (HIMF)")
+processed.associate_citation(citation, bibcode)
+processed.associate_name(name)
+processed.associate_comment(comment)
+processed.associate_redshift(redshift)
+processed.associate_plot_as(plot_as)
+processed.associate_cosmology(cosmology)
+
+output_path = f"{output_directory}/{output_filename}"
+
+if os.path.exists(output_path):
+    os.remove(output_path)
+
+processed.write(filename=output_path)

--- a/data/GalaxyHIMassFunction/raw/Ponomareva2023.txt
+++ b/data/GalaxyHIMassFunction/raw/Ponomareva2023.txt
@@ -1,0 +1,15 @@
+# The HI mass function from the MeerKAT telescope's data based on 276 direct detections from
+# the MIGHTEE Survey Early Science data covering redshifts 0 < z < 0.084 reported in
+# Ponomareva et al (2023). The raw data points are taken directly from Figure 3 in
+# Ponomareva et al (2023).
+# Log10 Mstar [Msun], Log10 HI Phi [(1/hMpc)**3], Phi Err+ [(1/hMpc)**3], Phi Err- [(1/hMpc)**3]
+8.0439 -1.8203 0.3430 5.0000
+8.3435 -1.7187 0.2795 0.9655
+8.6431 -1.4011 0.1652 0.2922
+8.9427 -1.6552 0.1652 0.2795
+9.2448 -1.7568 0.1397 0.2541
+9.5444 -2.0744 0.1525 0.2160
+9.8440 -2.0617 0.1397 0.2287
+10.1436 -2.4682 0.1397 0.2795
+10.4432 -3.1034 0.2160 0.5082
+10.7428 -3.8022 0.3557 3.0000


### PR DESCRIPTION
https://ui.adsabs.harvard.edu/abs/2023MNRAS.tmp.1270P/abstract

The raw data are the blue plots from Fig. 3 in the paper

![Screenshot from 2023-05-19 19-41-39](https://github.com/SWIFTSIM/velociraptor-comparison-data/assets/20153933/2dbf1e61-e92a-4252-900d-ed1d291bb126)

Here is how it will look like in our pipeline

![adaptive_gas_HI_mass_function](https://github.com/SWIFTSIM/velociraptor-comparison-data/assets/20153933/0fc375b2-a569-4c23-8444-e86d140510eb)

Note that both figures have the ALFALFA HI mass function from Jones et al 2018, against which the new data can be compared.