### PR TITLE
Correct solar value of Fe/H in the conversion script for Gallazzi+ 2021

### DIFF
--- a/data/GalaxyStellarMassAlphatoIron/conversion/convertGallazzi2021.py
+++ b/data/GalaxyStellarMassAlphatoIron/conversion/convertGallazzi2021.py
@@ -28,7 +28,14 @@ M_star = 10 ** raw[:, 0] * unyt.Solar_Mass * h_sim ** -2
 # From Grevesse + (1991) to Asplund+ (2009)
 
 O_over_H_Gr91 = 8.91
-Fe_over_H_Gr91 = 7.67
+
+# We don't take the Fe_over_H_Gr91 value of 7.67 from Grevesse + (1991), which was used
+# in Gallazzi et al. (2021) because we are confident that that value wasn't correct
+# and instead we need to use a more recent value, which is defined in the following.
+# line. We are currently waiting for a confirmation from Gallazzi that we should indeed
+# use 7.48, as opposed to 7.67.
+Fe_over_H_Gr91 = 7.48
+
 Mg_over_H_Gr91 = 7.58
 
 O_over_H_Asplund09 = 8.69
@@ -64,7 +71,7 @@ for element in element_list:
         "Data obtained assuming a Chabrier IMF and h=0.7. "
         f"h-corrected for SWIFT using cosmology: {cosmology.name}. "
         "The metallicity is expressed as [alpha/Fe]. Note that alpha does not stand for Oxygen. "
-        "Gallazi et al. adopt a semi-empirical estimate of [alpha/Fe] building on the work of Gallazzi et al. (2006). "
+        "Gallazzi et al. adopt a semi-empirical estimate of [alpha/Fe] building on the work of Gallazzi et al. (2006). "
         "For each galaxy they measure the index ratio Mgb/Fe. "
         "The error bars given the 16th and 84th percentile of the distribution. "
         f"This has been corrected to use Z_solar={solar_metallicity} (Asplund+ 2009)"


### PR DESCRIPTION
This pull request is initiated by Joop in his recent posts on the chemistry slack channel of Colibre. Here is the part of his posts from August 3 and 5, 2023 that is relevant to this PR:

"""
In [our [Mg/Fe] plot](https://swift.dur.ac.uk/COLIBREPlots/ccorrea/pipeline/2023_04_tests/Test_CCSN4/stellar_mass_star_mg_over_fe_50.png) Gallazzi+ is much lower than in their own fig. 4 (see below). A year ago Gallazzi emailed me they used solar abundances of 7.67 for Fe, 8.91 for O, and 7.58 for Mg. Hence, to convert from their [Mg/Fe] to Asplund, we need to add (7.58-7.67) - (7.60-7.50)  =  -0.19.

Since the low [Mg/Fe] that we get with that conversion make no sense to me, I decided to check the literature on stellar evolution on which Gallazzi+ is based. This took me most of the morning. It is a nightmare, you have to go back to the early 90s, incl. conference proceeding for which ADS is missing full text. The bottom line is that I think she got Fe wrong, partly because of a reference to the wrong Grevesse+91 in the paper about the Padova tracks (Bressan+93) that are used by Bruzual & Charlot 03.  This is important because at that time the photospheric Fe was sharply revised (solving a long-standing discrepancy with the meteoric value) and there are six Grevesse+91 papers on ADS, most of which are however unavailable.

The bottom line is that I think it should be 7.48 rather than 7.67. That would mean that to convert to Asplund we need to add  (7.58-7.48) - (7.60-7.50)  = 0, i.e. no change relative to her own Fig. 4 and 0.19 dex higher than how we show here data. This higher value would make a lot more sense.
"""
![image (2)](https://github.com/SWIFTSIM/velociraptor-comparison-data/assets/20153933/f12a8447-c123-4813-be6d-077e997d93b1)


